### PR TITLE
fix: harden transports, streaming, reports, and data-asset publish; i…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,19 @@ SEMANTIC_MODEL_PATH=sample_data/anime_streaming/semantic_model.yml
 # always active; set this for table/column allowlists and LIMIT enforcement.
 SQL_SECURITY_POLICY_PATH=
 
+# Transport hardening for network deployments (REST / SSE / Gateway / MCP).
+# When QUERYFORGE_API_KEY is set, every endpoint except /health requires
+# `Authorization: Bearer <key>` or `X-API-Key: <key>`.
+QUERYFORGE_API_KEY=
+# Comma-separated files/directories that remote callers may open as `database`
+# (also constrains semantic_model_path / sql_policy_path / subject_tree_path).
+# When empty, network transports fall back to the project root plus the
+# directory of DATABASE_PATH.
+DATABASE_ALLOWLIST=
+# Comma-separated directories that may receive generated HTML reports.
+# Defaults to REPORT_OUTPUT_DIR.
+REPORT_ROOT_ALLOWLIST=
+
 # Standard-library console + file logging
 LOG_LEVEL=INFO
 LOG_FILE=.queryforge/logs/queryforge.log

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ policy enforcement, bounded recovery, and production-friendly delivery interface
 ![Python](https://img.shields.io/badge/Python-3.11%20%7C%203.12-3776AB?logo=python&logoColor=white)
 ![SQLite](https://img.shields.io/badge/SQLite-read--only-003B57?logo=sqlite&logoColor=white)
 ![SQLGlot](https://img.shields.io/badge/SQL%20policy-SQLGlot-6B4FBB)
-![Tests](https://img.shields.io/badge/tests-247%20passing-2EA44F)
+![Tests](https://img.shields.io/badge/tests-270%20passing-2EA44F)
 ![Semantic contracts](https://img.shields.io/badge/semantic%20checks-82%20passing-7C3AED)
 
 </div>
@@ -472,6 +472,19 @@ project does **not** currently include:
 
 Keep REST and MCP transports inside a controlled environment. Do not commit
 provider secrets, generated run state, or local databases containing sensitive data.
+
+Network transports can be hardened without code changes:
+
+- `QUERYFORGE_API_KEY` — when set, REST/Gateway endpoints (except `/health`)
+  require `Authorization: Bearer <key>` or `X-API-Key: <key>`.
+- `DATABASE_ALLOWLIST` / `REPORT_ROOT_ALLOWLIST` — comma-separated directories
+  that confine caller-supplied `database`/`semantic_model_path`/`sql_policy_path`
+  and report output paths. Without them, network transports fall back to the
+  project root plus the default database directory.
+
+`POST /ask/stream` delivers progress events followed by one terminal
+`final_result` event carrying the serialized answer (or an `error`); clients
+that disconnect cancel the run cooperatively at the next node boundary.
 
 ## Roadmap
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,7 +14,7 @@
 ![Python](https://img.shields.io/badge/Python-3.11%20%7C%203.12-3776AB?logo=python&logoColor=white)
 ![SQLite](https://img.shields.io/badge/SQLite-只读执行-003B57?logo=sqlite&logoColor=white)
 ![SQLGlot](https://img.shields.io/badge/SQL%20治理-SQLGlot-6B4FBB)
-![Tests](https://img.shields.io/badge/tests-247%20passing-2EA44F)
+![Tests](https://img.shields.io/badge/tests-270%20passing-2EA44F)
 ![Semantic contracts](https://img.shields.io/badge/semantic%20checks-82%20passing-7C3AED)
 
 </div>
@@ -448,6 +448,17 @@ QueryForge 的安全保证适用于其配置后的 SQLite 执行边界。项目�
 
 请将 REST 和 MCP 接口部署在受控环境中，不要提交 Provider 密钥、运行状态，
 以及包含敏感数据的本地数据库。
+
+网络传输层无需改代码即可加固：
+
+- `QUERYFORGE_API_KEY` — 设置后，REST/Gateway 端点（`/health` 除外）要求
+  `Authorization: Bearer <key>` 或 `X-API-Key: <key>`。
+- `DATABASE_ALLOWLIST` / `REPORT_ROOT_ALLOWLIST` — 逗号分隔的目录列表，用于约束
+  调用方传入的 `database` / `semantic_model_path` / `sql_policy_path` 以及报告输出
+  路径。未配置时，网络传输层回退为「项目根目录 + 默认数据库所在目录」。
+
+`POST /ask/stream` 会先发送进度事件，最后以一个携带序列化答案（或 `error`）的
+终态 `final_result` 事件收尾；客户端断开连接后，运行会在下一个节点边界协作式取消。
 
 ## Roadmap
 

--- a/docs/nl2sql_evaluation.md
+++ b/docs/nl2sql_evaluation.md
@@ -41,21 +41,59 @@ and `candidate_selection`. Rejection cases use:
 }
 ```
 
-Policy probes are deliberately evaluated through the same read-only AST validator
-used by the platform, rather than relying on an LLM to reproduce unsafe SQL.
+Policy probes are evaluated through the **real governance path**: the same
+`SQLPolicyEngine` used at execution time, with the case's `sql_policy` (or the
+default policy) and the case's physical database schema. Table/column scope,
+LIMIT budgets, join rules, and dangerous-function rules are therefore actually
+measured — not just the static read-only rejections.
 
 ## Fixed Metrics
 
 - `sql_execution_success_rate`: successful workflow executions / query cases.
 - `semantic_correctness_rate`: result-set equivalence against the expected SQL,
-  independent of SQL formatting or an alternative valid query plan.
-- `policy_rejection_precision` and `policy_rejection_recall`: expected dangerous
-  probes vs safe expected SQL probes.
-- `p50_latency_ms` and `p95_latency_ms`: end-to-end final-turn query latency.
+  independent of SQL formatting or an alternative valid query plan. Comparison
+  is column-name aware: when the returned column set matches the expected set
+  but the order differs, rows are reordered before comparing, so a correct
+  answer in a different column order is not mis-scored as wrong.
+- `policy_rejection_precision` / `policy_rejection_recall`, measured over
+  **generated** SQL:
+  - true positive: a probe correctly rejected by the policy engine;
+  - false negative: a probe that slipped through (bypass);
+  - false positive: a legitimate query case whose generated SQL the engine
+    rejected. Precision therefore degrades when the policy is over-strict —
+    it is no longer tautologically 1.0.
+  - Supporting counts (`policy_true_positives`, `policy_false_positives`,
+    `policy_false_negatives`, `policy_probe_errors`) and the governing rule per
+    probe (`policy_rule`, `policy_name`) are included for audits.
+- `p50_latency_ms` / `p95_latency_ms`: final-turn query latency. Follow-up
+  warmup turns are excluded from each case's latency, and the first executed
+  case (which includes provider-client warmup) is excluded from the aggregates.
 - `average_estimated_input_tokens`, `average_estimated_output_tokens`, and
   `average_estimated_cost_usd`.
 - `candidate_selection_uplift`: selected candidate semantic correctness minus the
   first generated candidate's correctness on candidate-enabled cases.
+- `per_domain`: per-domain execution-success and semantic-correctness rates.
+
+The report also exposes `query_count`, `probe_count`, and `unique_case_count`
+so coverage is reported honestly (exact duplicate question+SQL pairs are
+counted once in `unique_case_count`).
+
+## Exit-Code Gates
+
+```bash
+python scripts/evaluate_sql.py \
+  --cases evaluation/gold/nl2sql_multidomain.jsonl \
+  --min-execution-success 1.0 \
+  --min-semantic-correct 0.8 \
+  --min-policy-recall 1.0
+```
+
+- `--min-execution-success` (default 1.0): fails when query cases run below the
+  threshold. Probe-only runs are exempt (the metric is not measurable there).
+- `--min-semantic-correct` (default 0.0, disabled): fails when semantic
+  correctness falls below the threshold.
+- `--min-policy-recall` (default 0.0, disabled): fails when any probe bypasses
+  the policy engine.
 
 Token and cost values are explicitly heuristic (`character_count / 4`) because the
 provider adapters do not expose normalized billing usage across all configured model

--- a/queryforge/application/agent_service.py
+++ b/queryforge/application/agent_service.py
@@ -9,6 +9,11 @@ from typing import Callable
 
 from queryforge.workflow.event_emitter import EventEmitter, emit_event
 from queryforge.workflow.workflow_runner import WorkflowRunner
+from queryforge.workflow.workflow import WorkflowCancelled
+from queryforge.interfaces.transport_security import (
+    NETWORK_ENTRYPOINTS,
+    validate_transport_options,
+)
 from queryforge.orchestration.agents.entry_router import EntryRouterAgent
 from queryforge.orchestration.agents.product_analyst import ProductAnalystAgent
 from queryforge.orchestration.agents.sql_review import SQLReviewAgent
@@ -74,7 +79,9 @@ class AgentService(ResourceService):
         run_id = resolved_options.run_id or new_run_id()
         resolved_options = replace(resolved_options, run_id=run_id)
         emitter = EventEmitter(config.streaming_event_buffer_size)
-        stream = WorkflowEventStream(emitter)
+        stream = WorkflowEventStream(
+            emitter, queue_maxsize=config.streaming_event_buffer_size
+        )
         emitter.on_event(stream._publish)
 
         def worker() -> None:
@@ -91,6 +98,7 @@ class AgentService(ResourceService):
                     resolved_options,
                     plan_only=False,
                     event_emitter=emitter,
+                    cancel_check=stream.is_cancelled,
                 )
                 emit_event(
                     emitter,
@@ -98,6 +106,22 @@ class AgentService(ResourceService):
                     run_id,
                     status=str(stream.result.get("status") or "success"),
                     message="QueryForge workflow completed.",
+                    result=stream.result,
+                )
+            except WorkflowCancelled:
+                stream.result = {
+                    "status": "cancelled",
+                    "run_id": run_id,
+                    "question": question,
+                    "reason": "Client disconnected before the workflow completed.",
+                }
+                emit_event(
+                    emitter,
+                    "final_result",
+                    run_id,
+                    status="cancelled",
+                    message="QueryForge workflow was cancelled.",
+                    result=stream.result,
                 )
             except Exception as exc:
                 stream.error = exc
@@ -107,6 +131,7 @@ class AgentService(ResourceService):
                     run_id,
                     status="failed",
                     message="QueryForge workflow failed.",
+                    error=str(exc),
                 )
             finally:
                 stream._close()
@@ -153,6 +178,7 @@ class AgentService(ResourceService):
         *,
         plan_only: bool,
         event_emitter: EventEmitter | None = None,
+        cancel_check: Callable[[], bool] | None = None,
     ) -> dict:
         question = question.strip()
         if not question:
@@ -163,6 +189,8 @@ class AgentService(ResourceService):
             model_override=options.model,
         )
         options.validate_for_config(config)
+        if options.entrypoint in NETWORK_ENTRYPOINTS:
+            validate_transport_options(config, options)
         database = options.database or config.database_path
         path = Path(database).expanduser()
         if not path.is_file():
@@ -256,6 +284,7 @@ class AgentService(ResourceService):
             "report_output_dir": options.report_output_dir,
             "report_max_rows": options.report_max_rows,
             "report_max_charts": options.report_max_charts,
+            "cancel_check": cancel_check,
         }
         runner_kwargs["run_id_factory"] = lambda: run_id
         task = SqlTask(question=question, database_path=str(path))

--- a/queryforge/application/event_stream.py
+++ b/queryforge/application/event_stream.py
@@ -2,24 +2,72 @@
 
 from __future__ import annotations
 
-from queue import Queue
+from queue import Empty, Full, Queue
+from threading import Event
 from typing import Iterator
 
 from queryforge.workflow.event_emitter import WorkflowEvent
 
+TERMINAL_EVENT_TYPE = "final_result"
+
 
 class WorkflowEventStream(Iterator[WorkflowEvent]):
-    def __init__(self, emitter) -> None:
+    """Consume progress events plus one terminal result/error event.
+
+    Progress events are bounded: when the queue is full the newest progress
+    event is dropped (progress-only information may be lost). The terminal
+    ``final_result`` event is never dropped; it evicts the oldest progress
+    event to make room when necessary. ``cancel`` cooperatively asks the
+    worker to stop at the next node boundary.
+    """
+
+    def __init__(self, emitter, queue_maxsize: int = 100) -> None:
         self.emitter = emitter
         self.result: dict | None = None
         self.error: Exception | None = None
-        self._queue: Queue[WorkflowEvent | None] = Queue()
+        self._queue: Queue[WorkflowEvent | None] = Queue(
+            maxsize=max(queue_maxsize, 1)
+        )
+        self._cancelled = Event()
 
     def _publish(self, event: WorkflowEvent) -> None:
-        self._queue.put(event)
+        if event.event_type == TERMINAL_EVENT_TYPE:
+            self._put_terminal(event)
+            return
+        try:
+            self._queue.put_nowait(event)
+        except Full:
+            # Progress-only events may be dropped under backpressure.
+            return
+
+    def _put_terminal(self, event: WorkflowEvent) -> None:
+        while True:
+            try:
+                self._queue.put_nowait(event)
+                return
+            except Full:
+                try:
+                    self._queue.get_nowait()
+                except Empty:
+                    continue
 
     def _close(self) -> None:
-        self._queue.put(None)
+        # Sentinel delivery must never block a finishing worker.
+        while True:
+            try:
+                self._queue.put_nowait(None)
+                return
+            except Full:
+                try:
+                    self._queue.get_nowait()
+                except Empty:
+                    continue
+
+    def cancel(self) -> None:
+        self._cancelled.set()
+
+    def is_cancelled(self) -> bool:
+        return self._cancelled.is_set()
 
     def __iter__(self) -> "WorkflowEventStream":
         return self

--- a/queryforge/application/resources.py
+++ b/queryforge/application/resources.py
@@ -14,6 +14,10 @@ from queryforge.domain.skills import SkillRegistry
 from queryforge.infrastructure.db.sqlite_connector import SQLiteConnector
 from queryforge.infrastructure.storage import SQLHistoryStore
 from queryforge.infrastructure.tools.database_tool import DatabaseTool
+from queryforge.interfaces.transport_security import (
+    validate_database_path,
+    validate_report_root,
+)
 from queryforge.orchestration.orchestrator.pipeline_registry import describe_pipelines
 from queryforge.workflow.workflow_runner import WorkflowRunner
 
@@ -85,6 +89,7 @@ class ResourceService:
         root = Path(
             report_output_dir or config.report_output_dir
         ).expanduser().resolve()
+        validate_report_root(config, report_output_dir)
         path = root / f"{run_id}.html"
         if not path.is_file():
             raise ValueError(f"Report does not exist for run_id {run_id!r}")
@@ -220,6 +225,7 @@ class ResourceService:
         sql_policy_path: str | None,
     ) -> Iterator[DatabaseTool]:
         config = self.config_loader()
+        validate_database_path(config, database)
         path = Path(database or config.database_path).expanduser()
         if not path.is_file():
             raise ValueError(f"SQLite database does not exist: {path}")

--- a/queryforge/core/config.py
+++ b/queryforge/core/config.py
@@ -74,6 +74,10 @@ class Config:
     mcp_history_limit: int = 20
     sql_policy_path: str | None = None
     orchestration_state_root: str = DEFAULT_ORCHESTRATION_STATE_ROOT
+    # Transport hardening for network deployments (REST/Gateway/MCP).
+    api_key: str | None = None
+    allowed_database_paths: tuple[str, ...] = ()
+    allowed_report_roots: tuple[str, ...] = ()
 
     def require_api_key(self) -> str:
         if not self.llm_api_key:
@@ -227,6 +231,11 @@ def load_config(
         orchestration_state_root=os.getenv(
             "ORCHESTRATION_STATE_ROOT", DEFAULT_ORCHESTRATION_STATE_ROOT
         ),
+        api_key=_optional_string(os.getenv("QUERYFORGE_API_KEY")),
+        allowed_database_paths=_environment_paths(
+            os.getenv("DATABASE_ALLOWLIST")
+        ),
+        allowed_report_roots=_environment_paths(os.getenv("REPORT_ROOT_ALLOWLIST")),
     )
 
 
@@ -253,7 +262,7 @@ def _environment_bool(value: str | None, *, default: bool) -> bool:
         return True
     if normalized in {"0", "false", "no", "off"}:
         return False
-    raise ValueError("SUBJECT_TREE_ENABLED must be a boolean value")
+    raise ValueError(f"environment value {value!r} must be a boolean")
 
 
 def _environment_int(value: str | None, *, default: int, minimum: int) -> int:
@@ -262,9 +271,18 @@ def _environment_int(value: str | None, *, default: int, minimum: int) -> int:
     try:
         parsed = int(value)
     except ValueError as exc:
-        raise ValueError("STREAMING_EVENT_BUFFER_SIZE must be an integer") from exc
+        raise ValueError(f"environment value {value!r} must be an integer") from exc
     if parsed < minimum:
-        raise ValueError(
-            f"STREAMING_EVENT_BUFFER_SIZE must be at least {minimum}"
-        )
+        raise ValueError(f"environment integer value must be at least {minimum}")
     return parsed
+
+
+def _environment_paths(value: str | None) -> tuple[str, ...]:
+    """Split a comma-separated path allowlist into clean, non-empty entries."""
+    if value is None:
+        return ()
+    return tuple(
+        entry.strip()
+        for entry in value.split(",")
+        if entry.strip()
+    )

--- a/queryforge/data_assets/pipeline.py
+++ b/queryforge/data_assets/pipeline.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-import shutil
+import logging
 import sqlite3
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -37,6 +37,12 @@ from queryforge.domain.semantic import (
 )
 from queryforge.infrastructure.db.sqlite_connector import SQLiteConnector
 from queryforge.infrastructure.tools.database_tool import DatabaseTool
+
+_logger = logging.getLogger("queryforge.data_assets")
+
+# Chunk size for streaming the published unique-key set out of SQLite so a huge
+# table is never materialised in one unbounded fetchall.
+_EXISTING_KEYS_CHUNK_SIZE = 10_000
 
 
 @dataclass(frozen=True)
@@ -87,13 +93,30 @@ class DataAssetBuilder:
         config: AssetBuildConfig,
         semantic_model_output: str | Path | None = None,
     ) -> list[AssetBuildResult]:
-        """Publish one atomic data-and-semantics batch."""
+        """Publish one atomic data-and-semantics batch.
+
+        An exclusive advisory lock (``fcntl.flock``) guards the whole batch so a
+        second concurrent builder fails fast instead of racing on the publish and
+        metadata databases.
+        """
         if not config.semantic_model.reviewed:
             raise DataAssetError(
                 "Upload blocked: semantic_model.reviewed must be true after a "
                 "human has reviewed entity grain, hidden columns, relationships, "
                 "Join Paths, and metric definitions."
             )
+        lock_handle = self._acquire_builder_lock()
+        try:
+            return self._build_all_unlocked(config, semantic_model_output)
+        finally:
+            self._release_builder_lock(lock_handle)
+
+    def _build_all_unlocked(
+        self,
+        config: AssetBuildConfig,
+        semantic_model_output: str | Path | None = None,
+    ) -> list[AssetBuildResult]:
+        """The locked batch body; the builder lock is held by :meth:`build_all`."""
         self.state_root.mkdir(parents=True, exist_ok=True)
         self.publish_database.parent.mkdir(parents=True, exist_ok=True)
         self._initialize_metadata()
@@ -127,6 +150,12 @@ class DataAssetBuilder:
                                 f"contract validation: {reason}"
                             )
                 except Exception as exc:
+                    _logger.error(
+                        "Semantic publication validation failed for %s: %s",
+                        pending_path,
+                        exc,
+                        exc_info=True,
+                    )
                     pending_path.unlink(missing_ok=True)
                     for result in results:
                         result.status = "failed"
@@ -238,6 +267,13 @@ class DataAssetBuilder:
             self._record_lineage(result, "success")
             return result
         except Exception as exc:
+            _logger.error(
+                "Asset %r build failed (run_id=%s): %s",
+                asset.name,
+                run_id,
+                exc,
+                exc_info=True,
+            )
             result.status = "failed"
             result.error = str(exc)
             result.quarantined_rows = len(quarantined)
@@ -377,11 +413,35 @@ class DataAssetBuilder:
             }
             if not set(key_columns).issubset(physical_columns):
                 return set()
-            rows = connection.execute(
-                f"SELECT {', '.join(_quote(column) for column in key_columns)} "
-                f"FROM {_quote(table)}"
-            ).fetchall()
-        return {tuple(row) for row in rows}
+            # The consumer (apply_quality_rules) needs the full key set for
+            # membership checks, so the set itself must live in memory; what we
+            # bound is the SQL read: keyset pagination by rowid streams bounded
+            # chunks instead of one unbounded fetchall of the whole table.
+            quoted_columns = ", ".join(_quote(column) for column in key_columns)
+            keys: set[tuple[Any, ...]] = set()
+            try:
+                last_rowid = 0
+                while True:
+                    rows = connection.execute(
+                        f"SELECT {quoted_columns}, rowid FROM {_quote(table)} "
+                        "WHERE rowid > ? ORDER BY rowid LIMIT ?",
+                        (last_rowid, _EXISTING_KEYS_CHUNK_SIZE),
+                    ).fetchall()
+                    if not rows:
+                        break
+                    for row in rows:
+                        keys.add(tuple(row[:-1]))
+                    last_rowid = rows[-1][-1]
+            except sqlite3.OperationalError as exc:
+                if "rowid" not in str(exc).lower():
+                    raise
+                # WITHOUT ROWID table: no stable rowid to page on; fall back to a
+                # single read so behaviour matches the historical full-table load.
+                rows = connection.execute(
+                    f"SELECT {quoted_columns} FROM {_quote(table)}"
+                ).fetchall()
+                keys = {tuple(row) for row in rows}
+        return keys
 
     def _publish(
         self,
@@ -396,36 +456,48 @@ class DataAssetBuilder:
             if list(row) != columns:
                 raise DataAssetError("Normalized rows do not share a stable schema")
         with sqlite3.connect(self.publish_database) as connection:
-            table_exists = connection.execute(
-                "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
-                (table,),
-            ).fetchone()
-            if mode == "replace":
-                connection.execute(f"DROP TABLE IF EXISTS {_quote(table)}")
-                table_exists = None
-            if not table_exists:
-                types = _infer_types(rows, columns)
-                definitions = ", ".join(
-                    f"{_quote(column)} {types[column]}" for column in columns
-                )
-                connection.execute(f"CREATE TABLE {_quote(table)} ({definitions})")
-            else:
-                existing = [
-                    str(row[1])
-                    for row in connection.execute(f"PRAGMA table_info({_quote(table)})")
-                ]
-                if existing != columns:
-                    raise DataAssetError(
-                        f"Published table {table!r} schema drift: expected {existing}, "
-                        f"received {columns}"
+            # Python's sqlite3 runs DDL in autocommit; without an explicit
+            # transaction a crash between DROP TABLE and the INSERT loop would
+            # permanently lose the previous table. BEGIN IMMEDIATE takes the
+            # write lock up front and COMMIT/ROLLBACK make the whole
+            # drop-create-insert atomic. Append mode gets the same guarantee.
+            connection.isolation_level = None
+            connection.execute("BEGIN IMMEDIATE")
+            try:
+                table_exists = connection.execute(
+                    "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+                    (table,),
+                ).fetchone()
+                if mode == "replace":
+                    connection.execute(f"DROP TABLE IF EXISTS {_quote(table)}")
+                    table_exists = None
+                if not table_exists:
+                    types = _infer_types(rows, columns)
+                    definitions = ", ".join(
+                        f"{_quote(column)} {types[column]}" for column in columns
                     )
-            placeholders = ", ".join("?" for _ in columns)
-            connection.executemany(
-                f"INSERT INTO {_quote(table)} "
-                f"({', '.join(_quote(column) for column in columns)}) "
-                f"VALUES ({placeholders})",
-                [[row[column] for column in columns] for row in rows],
-            )
+                    connection.execute(f"CREATE TABLE {_quote(table)} ({definitions})")
+                else:
+                    existing = [
+                        str(row[1])
+                        for row in connection.execute(f"PRAGMA table_info({_quote(table)})")
+                    ]
+                    if existing != columns:
+                        raise DataAssetError(
+                            f"Published table {table!r} schema drift: expected {existing}, "
+                            f"received {columns}"
+                        )
+                placeholders = ", ".join("?" for _ in columns)
+                connection.executemany(
+                    f"INSERT INTO {_quote(table)} "
+                    f"({', '.join(_quote(column) for column in columns)}) "
+                    f"VALUES ({placeholders})",
+                    [[row[column] for column in columns] for row in rows],
+                )
+                connection.commit()
+            except BaseException:
+                connection.rollback()
+                raise
         return len(rows)
 
     def _upsert_semantic_catalog(self, asset: DataAssetSpec, table: str) -> None:
@@ -607,24 +679,134 @@ class DataAssetBuilder:
         publish_backup = self.state_root / f".publish-{token}.sqlite"
         metadata_backup = self.state_root / f".metadata-{token}.sqlite"
         publish_existed = self.publish_database.is_file()
-        if publish_existed:
-            shutil.copy2(self.publish_database, publish_backup)
-        shutil.copy2(self.metadata_database, metadata_backup)
+        if not self.metadata_database.is_file():
+            raise DataAssetError(
+                "Cannot checkpoint publication: metadata database does not exist: "
+                f"{self.metadata_database}"
+            )
+        try:
+            if publish_existed:
+                self._backup_database(self.publish_database, publish_backup)
+            self._backup_database(self.metadata_database, metadata_backup)
+        except Exception as exc:
+            _logger.error(
+                "Failed to create publication checkpoint for %s: %s",
+                self.publish_database,
+                exc,
+                exc_info=True,
+            )
+            raise
         return _PublicationCheckpoint(
             publish_existed=publish_existed,
             publish_backup=publish_backup,
             metadata_backup=metadata_backup,
         )
 
+    @staticmethod
+    def _backup_database(source: Path, destination: Path) -> None:
+        """Snapshot one SQLite database with the :meth:`sqlite3.Connection.backup`
+        API instead of a raw file copy.
+
+        ``backup()`` reads a transactionally consistent snapshot even while the
+        source uses ``journal_mode=WAL``, which ``shutil.copy2`` cannot guarantee
+        (it would miss committed data still sitting in the ``-wal`` file).
+        ``PRAGMA wal_checkpoint(TRUNCATE)`` first folds any WAL content into the
+        main file, so the checkpoint file is self-contained and unambiguous (a
+        no-op for rollback-journal databases)."""
+        destination.unlink(missing_ok=True)
+        source_connection = sqlite3.connect(source)
+        try:
+            source_connection.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+            destination_connection = sqlite3.connect(destination)
+            try:
+                source_connection.backup(destination_connection)
+            finally:
+                destination_connection.close()
+        finally:
+            source_connection.close()
+
     def _restore_publication_checkpoint(
         self, checkpoint: "_PublicationCheckpoint"
     ) -> None:
-        if checkpoint.publish_existed:
-            shutil.copy2(checkpoint.publish_backup, self.publish_database)
-        else:
-            self.publish_database.unlink(missing_ok=True)
-        shutil.copy2(checkpoint.metadata_backup, self.metadata_database)
-        self._discard_publication_checkpoint(checkpoint)
+        failures: list[tuple[str, BaseException]] = []
+        try:
+            if checkpoint.publish_existed:
+                self._restore_from_backup(checkpoint.publish_backup, self.publish_database)
+            else:
+                self.publish_database.unlink(missing_ok=True)
+                self._remove_sidecar_files(self.publish_database)
+        except Exception as exc:
+            failures.append(("publish", exc))
+            _logger.error(
+                "Failed to restore publish database %s from checkpoint %s: %s",
+                self.publish_database,
+                checkpoint.publish_backup,
+                exc,
+                exc_info=True,
+            )
+        try:
+            self._restore_from_backup(checkpoint.metadata_backup, self.metadata_database)
+        except Exception as exc:
+            failures.append(("metadata", exc))
+            _logger.error(
+                "Failed to restore metadata database %s from checkpoint %s: %s",
+                self.metadata_database,
+                checkpoint.metadata_backup,
+                exc,
+                exc_info=True,
+            )
+        # Only discard a snapshot once its restore succeeded; keep failed ones for
+        # manual recovery.
+        if checkpoint.publish_existed and not any(
+            name == "publish" for name, _ in failures
+        ):
+            checkpoint.publish_backup.unlink(missing_ok=True)
+        if not any(name == "metadata" for name, _ in failures):
+            checkpoint.metadata_backup.unlink(missing_ok=True)
+        if failures:
+            raise failures[0][1]
+
+    @staticmethod
+    def _restore_from_backup(backup: Path, target: Path) -> None:
+        """Restore ``target`` from a snapshot produced by :meth:`_backup_database`.
+
+        Stale ``-wal``/``-shm``/``-journal`` sidecars of the live target must be
+        removed around the restore: SQLite would otherwise replay pre-rollback
+        writes from them over the restored snapshot and corrupt or revert it. The
+        restored file is a complete snapshot, so it must be read without any
+        leftover sidecars. A final read-only open smoke-tests the result."""
+        target.parent.mkdir(parents=True, exist_ok=True)
+        DataAssetBuilder._remove_sidecar_files(target)
+        target.unlink(missing_ok=True)
+        source_connection = sqlite3.connect(backup)
+        try:
+            destination_connection = sqlite3.connect(target)
+            try:
+                source_connection.backup(destination_connection)
+            finally:
+                destination_connection.close()
+        finally:
+            source_connection.close()
+        DataAssetBuilder._remove_sidecar_files(target)
+        # backup() copies the source's page header verbatim, so a snapshot of a
+        # WAL database restores with journal_mode=WAL and would immediately
+        # recreate -wal/-shm sidecars on the next open (even read-only). Normalise
+        # the restored file to rollback-journal mode so it is fully self-contained
+        # and safe to open read-only without any stale sidecars.
+        with sqlite3.connect(target) as connection:
+            connection.execute("PRAGMA journal_mode=DELETE").fetchone()
+        DataAssetBuilder._remove_sidecar_files(target)
+        read_only = sqlite3.connect(f"{target.as_uri()}?mode=ro", uri=True)
+        try:
+            read_only.execute("SELECT count(*) FROM sqlite_master").fetchone()
+        finally:
+            read_only.close()
+
+    @staticmethod
+    def _remove_sidecar_files(database: Path) -> None:
+        """Delete WAL/SHM/hot-journal files that may shadow a restored database."""
+        for suffix in ("-wal", "-shm", "-journal"):
+            Path(str(database) + suffix).unlink(missing_ok=True)
 
     @staticmethod
     def _discard_publication_checkpoint(
@@ -632,6 +814,50 @@ class DataAssetBuilder:
     ) -> None:
         checkpoint.publish_backup.unlink(missing_ok=True)
         checkpoint.metadata_backup.unlink(missing_ok=True)
+
+    def _acquire_builder_lock(self) -> Any:
+        """Take an exclusive advisory lock (``fcntl.flock``) for the whole batch.
+
+        A second concurrent builder fails fast with :class:`DataAssetError`
+        instead of racing on the publish/metadata databases. The lock file is left
+        in place after release — flock is tied to the open file description, so
+        unlinking it would only invite races on a fresh inode. Platforms without
+        ``fcntl`` (e.g. some Windows builds) degrade to a logged no-op."""
+        lock_path = self.publish_database.with_name(
+            self.publish_database.name + ".lock"
+        )
+        try:
+            import fcntl
+        except ImportError:
+            _logger.warning(
+                "fcntl unavailable; skipping builder lock for %s "
+                "(concurrent builds are not protected on this platform).",
+                self.publish_database,
+            )
+            return None
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        handle = lock_path.open("a+")
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError as exc:
+            handle.close()
+            raise DataAssetError(
+                "Another data-asset build is already publishing to "
+                f"{self.publish_database}; concurrent builders are not allowed "
+                f"(advisory lock held: {lock_path})."
+            ) from exc
+        return handle
+
+    @staticmethod
+    def _release_builder_lock(handle: Any) -> None:
+        if handle is None:
+            return
+        try:
+            import fcntl
+
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        finally:
+            handle.close()
 
     def _validate_semantic_publication(self, path: Path):
         with SQLiteConnector(str(self.publish_database)) as connector:
@@ -702,19 +928,28 @@ def _replace_table(database: Path, table: str, rows: list[dict[str, Any]]) -> No
         if list(row) != columns:
             raise DataAssetError("Normalized rows do not share a stable schema")
     with sqlite3.connect(database) as connection:
-        connection.execute(f"DROP TABLE IF EXISTS {_quote(table)}")
-        types = _infer_types(rows, columns)
-        connection.execute(
-            f"CREATE TABLE {_quote(table)} ("
-            + ", ".join(f"{_quote(column)} {types[column]}" for column in columns)
-            + ")"
-        )
-        connection.executemany(
-            f"INSERT INTO {_quote(table)} "
-            f"({', '.join(_quote(column) for column in columns)}) "
-            f"VALUES ({', '.join('?' for _ in columns)})",
-            [[row[column] for column in columns] for row in rows],
-        )
+        # Same DDL-in-autocommit hazard as _publish: wrap drop/create/insert in an
+        # explicit transaction so a mid-batch failure rolls the old table back.
+        connection.isolation_level = None
+        connection.execute("BEGIN IMMEDIATE")
+        try:
+            connection.execute(f"DROP TABLE IF EXISTS {_quote(table)}")
+            types = _infer_types(rows, columns)
+            connection.execute(
+                f"CREATE TABLE {_quote(table)} ("
+                + ", ".join(f"{_quote(column)} {types[column]}" for column in columns)
+                + ")"
+            )
+            connection.executemany(
+                f"INSERT INTO {_quote(table)} "
+                f"({', '.join(_quote(column) for column in columns)}) "
+                f"VALUES ({', '.join('?' for _ in columns)})",
+                [[row[column] for column in columns] for row in rows],
+            )
+            connection.commit()
+        except BaseException:
+            connection.rollback()
+            raise
 
 
 def _infer_types(rows: list[dict[str, Any]], columns: Iterable[str]) -> dict[str, str]:

--- a/queryforge/interfaces/api/app.py
+++ b/queryforge/interfaces/api/app.py
@@ -2,13 +2,31 @@
 
 from __future__ import annotations
 
-import json
 from typing import Callable
 
 from queryforge import __version__
 from queryforge.interfaces.api.schemas import AskRequest, GatewayWebhookRequest
 from queryforge.interfaces.gateway import GatewayAdapter
+from queryforge.interfaces.transport_security import request_api_key_matches
 from queryforge.application import AgentService
+
+# Security headers applied to served HTML reports (see report_generator.py,
+# which escapes embedded script JSON). ``script-src 'unsafe-inline'`` is
+# required by the inline vegaEmbed bootstrap; the ``</script>`` breakout itself
+# is closed by escaping, and nosniff prevents content-type sniffing attacks.
+REPORT_SECURITY_HEADERS = {
+    "X-Content-Type-Options": "nosniff",
+    "Content-Security-Policy": (
+        "default-src 'none'; "
+        "style-src 'unsafe-inline'; "
+        "script-src 'unsafe-inline' https://cdn.jsdelivr.net; "
+        "img-src 'self' data:; "
+        "font-src 'self' data:"
+    ),
+    "Cache-Control": "no-store",
+}
+
+_PUBLIC_PATHS = frozenset({"/health", "/openapi.json", "/docs", "/redoc"})
 
 
 class APIUnavailableError(RuntimeError):
@@ -17,8 +35,8 @@ class APIUnavailableError(RuntimeError):
 
 def create_app(service: AgentService | None = None):
     try:
-        from fastapi import FastAPI, HTTPException
-        from fastapi.responses import FileResponse, StreamingResponse
+        from fastapi import FastAPI, HTTPException, Request
+        from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
     except ImportError as exc:
         raise APIUnavailableError(
             "FastAPI server is unavailable. Install optional dependencies with: "
@@ -27,11 +45,35 @@ def create_app(service: AgentService | None = None):
 
     agent_service = service or AgentService()
     gateway = GatewayAdapter(agent_service)
+    try:
+        config = agent_service.config_loader()
+    except Exception:
+        # The application must still boot without a resolvable model config;
+        # transport hardening simply stays disabled in that case.
+        config = None
+    api_key_configured = bool(config and config.api_key)
+
     app = FastAPI(
         title="QueryForge API",
         version=__version__,
         description="Thin REST/Gateway transports over the shared AgentService.",
     )
+
+    @app.middleware("http")
+    async def transport_auth(request: Request, call_next):
+        if (
+            api_key_configured
+            and request.url.path not in _PUBLIC_PATHS
+            and not request_api_key_matches(
+                config,
+                request.headers.get("authorization"),
+                request.headers.get("x-api-key"),
+            )
+        ):
+            return JSONResponse(
+                {"detail": "Authentication required."}, status_code=401
+            )
+        return await call_next(request)
 
     def call(operation: Callable[[], dict | list]):
         try:
@@ -58,7 +100,7 @@ def create_app(service: AgentService | None = None):
         return call(lambda: agent_service.ask(request.question, request.to_options()))
 
     @app.post("/ask/stream")
-    def ask_stream(request: AskRequest):
+    def ask_stream(request: AskRequest, http: Request):
         try:
             event_stream = agent_service.stream(
                 request.question,
@@ -68,10 +110,22 @@ def create_app(service: AgentService | None = None):
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
         def sse_events():
-            for event in event_stream:
-                yield f"data: {event.model_dump_json()}\n\n"
+            try:
+                for event in event_stream:
+                    if await_disconnect(http):
+                        break
+                    yield f"data: {event.model_dump_json()}\n\n"
+            finally:
+                event_stream.cancel()
 
-        return StreamingResponse(sse_events(), media_type="text/event-stream")
+        return StreamingResponse(
+            sse_events(),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "X-Accel-Buffering": "no",
+            },
+        )
 
     @app.post("/plan")
     def plan(request: AskRequest):
@@ -84,6 +138,7 @@ def create_app(service: AgentService | None = None):
                 agent_service.report_path(run_id),
                 media_type="text/html",
                 filename=f"{run_id}.html",
+                headers=REPORT_SECURITY_HEADERS,
             )
         except ValueError as exc:
             raise HTTPException(status_code=404, detail=str(exc)) from exc
@@ -99,3 +154,14 @@ def create_app(service: AgentService | None = None):
         )
 
     return app
+
+
+def await_disconnect(http) -> bool:
+    """Detect a dropped SSE client when the ASGI layer supports it."""
+    detector = getattr(http, "is_disconnected", None)
+    if detector is None:
+        return False
+    try:
+        return bool(detector())
+    except RuntimeError:
+        return False

--- a/queryforge/interfaces/transport_security.py
+++ b/queryforge/interfaces/transport_security.py
@@ -1,0 +1,131 @@
+"""Transport-level authentication and path allowlisting for network entrypoints.
+
+The CLI is a local operator surface and is intentionally exempt. REST, SSE,
+Gateway, and MCP entrypoints must not let remote callers read arbitrary files,
+write reports into arbitrary directories, or burn model quota anonymously.
+Caller-supplied file paths are therefore confined to an explicit allowlist when
+one is configured, or to the project root plus the directory of the configured
+default database otherwise.
+"""
+
+from __future__ import annotations
+
+import hmac
+from pathlib import Path
+
+from queryforge.core.config import PROJECT_ROOT, Config
+from queryforge.application.options import AgentOptions
+
+# Entrypoints that reach QueryForge over a network transport.
+NETWORK_ENTRYPOINTS = frozenset({"api", "api_stream", "gateway", "mcp"})
+
+
+class TransportAuthError(ValueError):
+    """Raised when a transport request fails the API-key gate."""
+
+
+def request_api_key_matches(
+    config: Config,
+    authorization: str | None,
+    x_api_key: str | None,
+) -> bool:
+    """Constant-time comparison of the request credential with the configured key.
+
+    Disabled (returns True) when no API key is configured, keeping local-first
+    deployments unchanged.
+    """
+    expected = (config.api_key or "").strip()
+    if not expected:
+        return True
+    bearer = ""
+    if authorization:
+        scheme, separator, token = authorization.partition(" ")
+        if scheme.lower() == "bearer" and separator:
+            bearer = token.strip()
+    supplied = (bearer or (x_api_key or "")).strip()
+    if not supplied:
+        return False
+    return hmac.compare_digest(supplied.encode("utf-8"), expected.encode("utf-8"))
+
+
+def _resolve_entry(entry: str) -> Path:
+    path = Path(entry).expanduser()
+    if not path.is_absolute():
+        path = PROJECT_ROOT / path
+    return path.resolve()
+
+
+def _entry_root(entry: str) -> Path:
+    """Map an allowlist entry to a directory root.
+
+    Existing files confine the root to their parent directory; everything else
+    (including not-yet-created paths) is treated as a directory entry so a
+    misconfigured path never silently widens the allowlist.
+    """
+    resolved = _resolve_entry(entry)
+    return resolved.parent if resolved.is_file() else resolved
+
+
+def database_roots(config: Config) -> tuple[Path, ...]:
+    """Directory roots that may contain caller-supplied database/semantic files."""
+    if config.allowed_database_paths:
+        return tuple(_entry_root(entry) for entry in config.allowed_database_paths)
+    fallback = [PROJECT_ROOT.resolve()]
+    try:
+        fallback.append(Path(config.database_path).expanduser().resolve().parent)
+    except (OSError, ValueError):
+        pass
+    return tuple(fallback)
+
+
+def report_roots(config: Config) -> tuple[Path, ...]:
+    """Directories that may receive generated HTML reports."""
+    if config.allowed_report_roots:
+        return tuple(_entry_root(entry) for entry in config.allowed_report_roots)
+    return (_resolve_entry(config.report_output_dir),)
+
+
+def _is_within(path: Path, roots: tuple[Path, ...]) -> bool:
+    return any(path == root or root in path.parents for root in roots)
+
+
+def validate_file_path(
+    config: Config,
+    label: str,
+    value: str | None,
+    roots: tuple[Path, ...],
+) -> None:
+    """Reject a caller-supplied path outside the allowed roots."""
+    if value is None:
+        return
+    resolved = Path(value).expanduser().resolve()
+    if not _is_within(resolved, roots):
+        raise ValueError(
+            f"{label} {value!r} is outside the allowed transport paths; "
+            "configure DATABASE_ALLOWLIST or REPORT_ROOT_ALLOWLIST to extend "
+            "the permitted locations"
+        )
+
+
+def validate_transport_options(config: Config, options: AgentOptions) -> None:
+    """Confine every caller-supplied file path on a network entrypoint."""
+    roots = database_roots(config)
+    validate_file_path(config, "database", options.database, roots)
+    validate_file_path(config, "semantic_model_path", options.semantic_model_path, roots)
+    validate_file_path(config, "sql_policy_path", options.sql_policy_path, roots)
+    validate_file_path(config, "subject_tree_path", options.subject_tree_path, roots)
+    validate_file_path(
+        config, "report_output_dir", options.report_output_dir, report_roots(config)
+    )
+
+
+def validate_database_path(config: Config, database: str | None) -> None:
+    """Confine an explicitly supplied database path (resource endpoints)."""
+    validate_file_path(config, "database", database, database_roots(config))
+
+
+def validate_report_root(config: Config, report_output_dir: str | None) -> None:
+    """Confine an explicitly supplied report directory."""
+    validate_file_path(
+        config, "report_output_dir", report_output_dir, report_roots(config)
+    )

--- a/queryforge/workflow/event_emitter.py
+++ b/queryforge/workflow/event_emitter.py
@@ -26,7 +26,12 @@ EventType = Literal[
 
 
 class WorkflowEvent(BaseModel):
-    """A progress-only event. SQL text, prompts, and result rows are excluded."""
+    """A progress-only event. SQL text, prompts, and result rows are excluded.
+
+    The terminal ``final_result`` event is the one exception: it carries the
+    serialized workflow result (or a failure message) so streaming transports
+    can deliver the answer without polling a second channel.
+    """
 
     event_id: str = Field(default_factory=lambda: f"evt_{uuid4().hex}")
     event_type: EventType
@@ -40,6 +45,8 @@ class WorkflowEvent(BaseModel):
     status: str | None = None
     message: str | None = None
     data: dict[str, Any] | None = None
+    result: dict[str, Any] | None = None
+    error: str | None = None
 
 
 class EventEmitter:

--- a/queryforge/workflow/report_generator.py
+++ b/queryforge/workflow/report_generator.py
@@ -247,7 +247,9 @@ th,td{{border:1px solid #e5e7eb;padding:8px;text-align:left}} th{{background:#f3
             )
             return f"<section><h2>{title}</h2>{notice}<table><thead><tr>{headers}</tr></thead><tbody>{rows}</tbody></table></section>"
         if section.type == "chart":
-            spec = json.dumps(content["spec"], ensure_ascii=False)
+            # Escape "</" so user-controlled spec values (question titles and
+            # result cells) can never terminate the enclosing <script> tag.
+            spec = json.dumps(content["spec"], ensure_ascii=False).replace("</", "<\\/")
             fallback = ReportGenerator._chart_fallback_svg(content["spec"])
             return (
                 f'<section><h2>{title}</h2><p>{html.escape(content["reason"])}</p>'

--- a/queryforge/workflow/workflow.py
+++ b/queryforge/workflow/workflow.py
@@ -91,6 +91,10 @@ class WorkflowError(RuntimeError):
         self.context = context
 
 
+class WorkflowCancelled(WorkflowError):
+    """Raised when a streaming client disconnects and the run should stop."""
+
+
 class Workflow:
     def __init__(self, context: Context, nodes: list[Node]) -> None:
         self.context = context
@@ -135,6 +139,7 @@ class ReflectiveWorkflow:
         max_retries: int = 2,
         analysis_hook: Callable[[Context], None] | None = None,
         candidate_hook: Callable[[Context], None] | None = None,
+        cancel_check: Callable[[], bool] | None = None,
     ) -> None:
         if max_retries < 0:
             raise ValueError("max_retries must be zero or greater")
@@ -153,6 +158,7 @@ class ReflectiveWorkflow:
         self.max_retries = max_retries
         self.analysis_hook = analysis_hook
         self.candidate_hook = candidate_hook
+        self.cancel_check = cancel_check
 
     def run(self) -> dict:
         for node in self.setup_nodes:
@@ -174,6 +180,7 @@ class ReflectiveWorkflow:
                 self._run_required(self.gen_sql_node)
 
         while True:
+            self._check_cancelled()
             if self.candidate_hook is not None:
                 self._run_hook("agent_candidate", self.candidate_hook)
                 if getattr(self.context, "final_output", None) is not None:
@@ -340,7 +347,16 @@ class ReflectiveWorkflow:
         return result
 
     def _run(self, node: Node) -> NodeResult:
+        self._check_cancelled()
         return _execute_observed_node(self.context, node)
+
+    def _check_cancelled(self) -> None:
+        if self.cancel_check is not None and self.cancel_check():
+            raise WorkflowCancelled(
+                "cancelled",
+                "Workflow cancelled because the streaming client disconnected.",
+                self.context,
+            )
 
     def _run_hook(self, name: str, hook: Callable[[Context], None]) -> None:
         try:

--- a/queryforge/workflow/workflow_runner.py
+++ b/queryforge/workflow/workflow_runner.py
@@ -135,6 +135,7 @@ class WorkflowRunner:
         report_output_dir: str | None = None,
         report_max_rows: int | None = None,
         report_max_charts: int | None = None,
+        cancel_check: Callable[[], bool] | None = None,
     ) -> None:
         self.config = config
         self.llm_factory = llm_factory
@@ -191,6 +192,7 @@ class WorkflowRunner:
         self.report_output_dir = report_output_dir or config.report_output_dir
         self.report_max_rows = report_max_rows or config.report_max_rows
         self.report_max_charts = report_max_charts or config.report_max_charts
+        self.cancel_check = cancel_check
 
     @classmethod
     def describe_workflow(cls) -> str:
@@ -413,6 +415,7 @@ class WorkflowRunner:
                     if self.candidate_hook is not None
                     else None
                 ),
+                cancel_check=self.cancel_check,
             ).run()
             if self.completion_hook is not None:
                 try:

--- a/scripts/evaluate_sql.py
+++ b/scripts/evaluate_sql.py
@@ -1,7 +1,10 @@
 """Evaluate QueryForge against multi-domain NL2SQL gold cases.
 
 The evaluator reports exact SQL agreement separately from semantic result equivalence.
-Token and cost values are deterministic estimates, not provider-reported billing usage.
+Policy precision/recall is measured over *generated* SQL: rejection probes must be
+rejected by the real policy engine (with the case's sql_policy), and any legitimate
+query case whose generated SQL is rejected counts as a false positive. Token and
+cost values are deterministic estimates, not provider-reported billing usage.
 """
 
 from __future__ import annotations
@@ -24,6 +27,7 @@ if str(PROJECT_ROOT) not in sys.path:
 
 from queryforge.application import AgentOptions, AgentService
 from queryforge.data_assets import DataAssetBuilder
+from queryforge.domain.security import SQLPolicyViolation, load_sql_policy
 from queryforge.infrastructure.db.sqlite_connector import SQLiteConnector
 from queryforge.infrastructure.tools.database_tool import DatabaseTool
 
@@ -57,6 +61,26 @@ def parse_args() -> argparse.Namespace:
         type=float,
         default=0.0,
         help="Estimated output-token USD price per million tokens",
+    )
+    parser.add_argument(
+        "--min-execution-success",
+        type=float,
+        default=1.0,
+        help="Exit-code gate: minimum sql_execution_success_rate (0..1)",
+    )
+    parser.add_argument(
+        "--min-semantic-correct",
+        type=float,
+        default=0.0,
+        help="Exit-code gate: minimum semantic_correctness_rate (0..1); "
+        "0 disables the gate",
+    )
+    parser.add_argument(
+        "--min-policy-recall",
+        type=float,
+        default=0.0,
+        help="Exit-code gate: minimum policy_rejection_recall over probes (0..1); "
+        "0 disables the gate",
     )
     return parser.parse_args()
 
@@ -148,7 +172,9 @@ def evaluate_cases(
             case, default_database, default_semantic_model
         )
         if case.get("expected_outcome") == "policy_rejection":
-            result = _evaluate_policy_probe(case, database)
+            result = _evaluate_policy_probe(
+                case, database, default_sql_policy=default_sql_policy
+            )
         else:
             result = _evaluate_query(
                 case,
@@ -207,6 +233,8 @@ def _evaluate_query(
                     run_id=f"evaluation_warmup_{index}_{turn}",
                 ),
             )
+        # Latency measures the evaluated turn only; warmup turns are excluded.
+        started = time.perf_counter()
         output = service.ask(
             case["question"],
             AgentOptions(
@@ -221,16 +249,26 @@ def _evaluate_query(
                 run_id=f"evaluation_{index}",
             ),
         )
-        expected_rows = _execute_expected(database, case.get("expected_sql"))
-        expected_policy_rejected = False
-        policy_rejected = _is_policy_rejected(str(case.get("expected_sql") or ""))
-        semantic_correct = _canonical_rows(output.get("rows", [])) == _canonical_rows(
-            expected_rows
+        expected_columns, expected_rows = _execute_expected(
+            database, case.get("expected_sql")
+        )
+        # Policy outcome of the *generated* SQL: rejecting a legitimate query is
+        # a false positive; trusting the expected SQL would make precision
+        # tautologically 1.0.
+        policy_rejected = _generated_policy_outcome(output)
+        semantic_correct = _semantic_equivalent(
+            output.get("rows", []),
+            output.get("columns"),
+            expected_rows,
+            expected_columns,
         )
         selection = output.get("candidate_selection") or {}
         candidates = selection.get("candidates", [])
         first_candidate_correct = _candidate_correct(
-            candidates[0].get("sql") if candidates else None, database, expected_rows
+            candidates[0].get("sql") if candidates else None,
+            database,
+            expected_rows,
+            expected_columns,
         )
         return {
             "id": case.get("id", index),
@@ -243,7 +281,7 @@ def _evaluate_query(
             "sql_exact_match": normalize_sql(output.get("sql"))
             == normalize_sql(case.get("expected_sql")),
             "policy_rejected": policy_rejected,
-            "policy_expected_rejection": expected_policy_rejected,
+            "policy_expected_rejection": False,
             "row_count": output.get("row_count"),
             "latency_ms": round((time.perf_counter() - started) * 1000, 3),
             "sql": output.get("sql"),
@@ -275,52 +313,180 @@ def _evaluate_query(
         }
 
 
-def _evaluate_policy_probe(case: dict[str, Any], database: Path) -> dict[str, Any]:
+def _evaluate_policy_probe(
+    case: dict[str, Any],
+    database: Path,
+    *,
+    default_sql_policy: str | None = None,
+) -> dict[str, Any]:
+    """Run one rejection probe through the real policy engine.
+
+    The probe is evaluated against the same ``DatabaseTool`` governance path
+    used at execution time, with the case's ``sql_policy`` (or the default),
+    so table/column scope, LIMIT budgets, and join rules are actually measured.
+    """
     started = time.perf_counter()
     probe = str(case.get("policy_probe_sql") or "")
-    rejected = _is_policy_rejected(probe)
+    if not probe:
+        return {
+            "id": case.get("id"),
+            "domain": case.get("domain", "default"),
+            "category": "policy_rejection",
+            "expected_outcome": "policy_rejection",
+            "status": "error",
+            "policy_rejected": None,
+            "policy_expected_rejection": True,
+            "policy_rule": None,
+            "policy_name": None,
+            "latency_ms": round((time.perf_counter() - started) * 1000, 3),
+            "sql": probe,
+            "candidates": [],
+            "candidate_selection_used": False,
+            "error": "policy_probe_sql is missing",
+        }
+    rejected = False
+    rule: str | None = None
+    policy_name: str | None = None
+    error: str | None = None
+    try:
+        policy_path = (
+            _project_path(str(case.get("sql_policy")))
+            if case.get("sql_policy")
+            else (
+                _project_path(default_sql_policy)
+                if default_sql_policy
+                else None
+            )
+        )
+        policy, policy_source = load_sql_policy(policy_path)
+        policy_name = policy.name
+        with SQLiteConnector(str(database)) as connector:
+            tool = DatabaseTool(
+                connector, policy, policy_source_path=policy_source
+            )
+            try:
+                decision = tool.policy_engine.evaluate(probe)
+                rule = decision.rule
+            except SQLPolicyViolation as exc:
+                rejected = True
+                rule = exc.decision.rule
+    except Exception as exc:
+        error = str(exc)
     return {
         "id": case.get("id"),
         "domain": case.get("domain", "default"),
         "category": "policy_rejection",
         "expected_outcome": "policy_rejection",
-        "status": "rejected" if rejected else "accepted",
+        "status": (
+            "error" if error else "rejected" if rejected else "accepted"
+        ),
         "policy_rejected": rejected,
         "policy_expected_rejection": True,
+        "policy_rule": rule,
+        "policy_name": policy_name,
         "latency_ms": round((time.perf_counter() - started) * 1000, 3),
         "sql": probe,
         "candidates": [],
         "candidate_selection_used": False,
-        "error": None,
+        "error": error,
     }
 
 
-def _execute_expected(database: Path, sql: str | None) -> list[list[Any]]:
+def _execute_expected(
+    database: Path, sql: str | None
+) -> tuple[list[str], list[list[Any]]]:
     if not sql:
-        return []
+        return [], []
     with SQLiteConnector(str(database)) as connector:
-        return connector.execute_sql(DatabaseTool.validate_readonly_sql(sql)).rows
+        result = connector.execute_sql(DatabaseTool.validate_readonly_sql(sql))
+        return result.columns, result.rows
 
 
-def _is_policy_rejected(sql: str) -> bool:
-    try:
-        DatabaseTool.validate_readonly_sql(sql)
-        return False
-    except Exception:
+def _generated_policy_outcome(output: dict[str, Any]) -> bool | None:
+    """Extract the policy outcome of the SQL that was actually generated.
+
+    Returns True when the policy engine rejected the generated SQL (a false
+    positive for a legitimate query case), False when it was allowed, and
+    None when the outcome is unknown.
+    """
+    decisions = (output.get("sql_security") or {}).get("decisions") or []
+    for decision in reversed(decisions):
+        allowed = decision.get("allowed")
+        if isinstance(allowed, bool):
+            return not allowed
+    if output.get("status") == "blocked":
         return True
+    if output.get("status") == "success":
+        return False
+    return None
 
 
-def _candidate_correct(sql: str | None, database: Path, expected_rows: list[list[Any]]) -> bool | None:
+def _candidate_correct(
+    sql: str | None,
+    database: Path,
+    expected_rows: list[list[Any]],
+    expected_columns: list[str],
+) -> bool | None:
     if not sql:
         return None
     try:
-        return _canonical_rows(_execute_expected(database, sql)) == _canonical_rows(expected_rows)
+        columns, rows = _execute_expected(database, sql)
+        return _semantic_equivalent(rows, columns, expected_rows, expected_columns)
     except Exception:
         return False
 
 
+def _semantic_equivalent(
+    actual_rows: list[list[Any]],
+    actual_columns: list[str] | None,
+    expected_rows: list[list[Any]],
+    expected_columns: list[str],
+) -> bool:
+    """Compare result sets by content, tolerant to column order and row order.
+
+    When the actual and expected column name sets match but their order
+    differs, actual rows are reordered to the expected column order before
+    comparison; otherwise comparison falls back to positional values.
+    """
+    reordered = _reorder_columns(
+        list(actual_columns or []), actual_rows, expected_columns
+    )
+    return _canonical_rows(reordered) == _canonical_rows(expected_rows)
+
+
+def _reorder_columns(
+    actual_columns: list[str],
+    rows: list[list[Any]],
+    expected_columns: list[str],
+) -> list[list[Any]]:
+    if (
+        actual_columns
+        and expected_columns
+        and len(actual_columns) == len(expected_columns)
+        and actual_columns != expected_columns
+        and set(actual_columns) == set(expected_columns)
+    ):
+        positions = [actual_columns.index(column) for column in expected_columns]
+        return [[row[position] for position in positions] for row in rows]
+    return rows
+
+
 def _canonical_rows(rows: list[list[Any]]) -> list[str]:
-    return sorted(json.dumps(row, ensure_ascii=False, sort_keys=True, default=str) for row in rows)
+    return sorted(
+        json.dumps(
+            [_canonical_value(value) for value in row],
+            ensure_ascii=False,
+            sort_keys=True,
+            default=str,
+        )
+        for row in rows
+    )
+
+
+def _canonical_value(value: Any) -> Any:
+    if isinstance(value, float) and math.isfinite(value) and value.is_integer():
+        return int(value)
+    return value
 
 
 def _estimate_tokens(text: str) -> int:
@@ -344,8 +510,8 @@ def _rate(values: list[bool]) -> float | None:
 
 def _build_report(results: list[dict[str, Any]]) -> dict[str, Any]:
     query_results = [item for item in results if item["expected_outcome"] == "query"]
-    policy_results = [
-        item for item in results if item.get("policy_rejected") is not None
+    probe_results = [
+        item for item in results if item["expected_outcome"] == "policy_rejection"
     ]
     selection_results = [item for item in query_results if item["candidate_selection_used"]]
     first_correct = [
@@ -358,26 +524,56 @@ def _build_report(results: list[dict[str, Any]]) -> dict[str, Any]:
         for item in selection_results
         if item.get("first_candidate_semantic_correct") is not None
     ]
+    # Policy metrics over *generated* SQL:
+    # - TP: probe correctly rejected by the real policy engine.
+    # - FN: probe that slipped through (bypass).
+    # - FP: legitimate query case whose generated SQL the engine rejected.
     true_positives = sum(
-        bool(item["policy_rejected"]) and bool(item["policy_expected_rejection"])
-        for item in policy_results
-    )
-    false_positives = sum(
-        bool(item["policy_rejected"]) and not bool(item["policy_expected_rejection"])
-        for item in policy_results
+        bool(item["policy_rejected"]) for item in probe_results
+        if item.get("policy_rejected") is not None
     )
     false_negatives = sum(
-        not bool(item["policy_rejected"]) and bool(item["policy_expected_rejection"])
-        for item in policy_results
+        not bool(item["policy_rejected"]) for item in probe_results
+        if item.get("policy_rejected") is not None
     )
+    false_positives = sum(
+        bool(item.get("policy_rejected")) for item in query_results
+    )
+    probe_errors = [
+        item for item in probe_results if item.get("status") == "error"
+    ]
     domains = sorted({str(item["domain"]) for item in results})
+    # The first executed query case includes provider-client warmup; exclude it
+    # from latency aggregates when other samples exist (per-case latencies stay
+    # in the results).
+    latency_cases = query_results[1:] if len(query_results) > 1 else query_results
+    per_domain: dict[str, dict[str, Any]] = {}
+    for domain in sorted({str(item["domain"]) for item in query_results}):
+        domain_results = [item for item in query_results if item["domain"] == domain]
+        per_domain[domain] = {
+            "cases": len(domain_results),
+            "sql_execution_success_rate": _rate(
+                [bool(item["execution_success"]) for item in domain_results]
+            ),
+            "semantic_correctness_rate": _rate(
+                [bool(item["semantic_correct"]) for item in domain_results]
+            ),
+        }
+    unique_queries = {
+        (str(item.get("question")), str(item.get("sql") or item.get("policy_probe_sql") or ""))
+        for item in results
+    }
     return {
         "case_count": len(results),
+        "query_count": len(query_results),
+        "probe_count": len(probe_results),
+        "unique_case_count": len(unique_queries),
         "domains": domains,
         "coverage": {
             category: sum(item["category"] == category for item in results)
             for category in sorted({str(item["category"]) for item in results})
         },
+        "per_domain": per_domain,
         "metrics": {
             "sql_execution_success_rate": _rate(
                 [bool(item["execution_success"]) for item in query_results]
@@ -398,11 +594,18 @@ def _build_report(results: list[dict[str, Any]]) -> dict[str, Any]:
             )
             if true_positives + false_negatives
             else None,
+            "policy_true_positives": true_positives,
+            "policy_false_positives": false_positives,
+            "policy_false_negatives": false_negatives,
+            "policy_probe_errors": len(probe_errors),
             "p50_latency_ms": _percentile(
-                [float(item["latency_ms"]) for item in query_results], 0.50
+                [float(item["latency_ms"]) for item in latency_cases], 0.50
             ),
             "p95_latency_ms": _percentile(
-                [float(item["latency_ms"]) for item in query_results], 0.95
+                [float(item["latency_ms"]) for item in latency_cases], 0.95
+            ),
+            "latency_warmup_excluded_case": (
+                query_results[0].get("id") if query_results else None
             ),
             "average_estimated_input_tokens": _average(
                 [int(item["estimated_input_tokens"]) for item in results]
@@ -421,6 +624,10 @@ def _build_report(results: list[dict[str, Any]]) -> dict[str, Any]:
             "candidate_selection_cases": len(first_correct),
         },
         "token_cost_method": "heuristic char_count/4; configure per-million prices for estimated USD only",
+        "policy_evaluation_method": (
+            "probes run through the real SQLPolicyEngine with the case's "
+            "sql_policy; query-case rejections count as false positives"
+        ),
         "results": results,
     }
 
@@ -451,7 +658,53 @@ def main() -> int:
     )
     Path(args.output).write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
     print(json.dumps(report["metrics"], ensure_ascii=False, indent=2))
-    return 0 if report["metrics"]["sql_execution_success_rate"] == 1.0 else 1
+    failures = _gate_failures(report, args)
+    for reason in failures:
+        print(f"[gate] FAILED: {reason}", file=sys.stderr)
+    if failures:
+        return 1
+    print("[gate] PASSED", file=sys.stderr)
+    return 0
+
+
+def _gate_failures(report: dict[str, Any], args: argparse.Namespace) -> list[str]:
+    """Exit-code gates that are only evaluated where measurable.
+
+    A gate configured at its default (0.0) or with no applicable cases does
+    not block; a gate configured with an explicit threshold fails when the
+    measured rate is below it.
+    """
+    metrics = report["metrics"]
+    failures: list[str] = []
+    if report["query_count"]:
+        execution = metrics["sql_execution_success_rate"]
+        if (
+            args.min_execution_success > 0
+            and execution is not None
+            and execution < args.min_execution_success
+        ):
+            failures.append(
+                f"sql_execution_success_rate={execution} below "
+                f"--min-execution-success {args.min_execution_success}"
+            )
+        semantic = metrics["semantic_correctness_rate"]
+        if (
+            args.min_semantic_correct > 0
+            and semantic is not None
+            and semantic < args.min_semantic_correct
+        ):
+            failures.append(
+                f"semantic_correctness_rate={semantic} below "
+                f"--min-semantic-correct {args.min_semantic_correct}"
+            )
+    if report["probe_count"] and args.min_policy_recall > 0:
+        recall = metrics["policy_rejection_recall"]
+        if recall is not None and recall < args.min_policy_recall:
+            failures.append(
+                f"policy_rejection_recall={recall} below "
+                f"--min-policy-recall {args.min_policy_recall}"
+            )
+    return failures
 
 
 if __name__ == "__main__":

--- a/tests/test_data_assets.py
+++ b/tests/test_data_assets.py
@@ -8,10 +8,29 @@ from unittest.mock import patch
 from queryforge.data_assets import (
     AssetBuildConfig,
     DataAssetBuilder,
+    DataAssetError,
     scaffold_asset_config,
 )
 from queryforge.domain.semantic import SemanticModelLoader
 from queryforge.infrastructure.db.sqlite_connector import SQLiteConnector
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - non-POSIX platforms
+    fcntl = None
+
+
+class _FailingExecutemanyConnection(sqlite3.Connection):
+    """A sqlite3 connection subclass that raises inside executemany when the SQL
+    matches a target statement, simulating a crash inside the publish INSERT loop.
+    Instances are still real sqlite3.Connection objects, so the backup() API
+    accepts them as destinations."""
+
+    def executemany(self, sql, parameters):
+        failing_sql = getattr(self, "_failing_sql", None)
+        if failing_sql and failing_sql in sql:
+            raise RuntimeError("injected failure inside the publish INSERT loop")
+        return super().executemany(sql, parameters)
 
 
 class _JsonResponse:
@@ -51,6 +70,180 @@ class DataAssetBuilderTest(unittest.TestCase):
 
     def tearDown(self):
         self.directory.cleanup()
+
+    def _watch_events_config(self, publish_mode="append"):
+        """A reviewed one-asset batch for the shared watch_events CSV."""
+        return AssetBuildConfig.model_validate(
+            {
+                "semantic_model": {
+                    "name": "anime_uploads",
+                    "description": "Reviewed anime upload semantics.",
+                    "owner": "analytics",
+                    "reviewed": True,
+                },
+                "assets": [
+                    {
+                        "name": "watch_events",
+                        "target_table": "fact_watch_events",
+                        "source": {"type": "csv", "path": str(self.csv_path)},
+                        "column_aliases": {
+                            "Event ID": "event_id",
+                            "Anime Title": "anime_title",
+                            "Watched At": "watched_at",
+                        },
+                        "quality": {
+                            "required_columns": [
+                                "event_id",
+                                "anime_title",
+                                "watched_at",
+                            ],
+                            "unique_key": ["event_id"],
+                        },
+                        "publish_mode": publish_mode,
+                        "semantic": {
+                            "entity_name": "watch_events",
+                            "entity_type": "fact",
+                            "description": "Reviewed anime playback events.",
+                            "grain": ["event_id"],
+                            "owner": "analytics",
+                            "sla": "P1D",
+                            "refresh_frequency": "daily",
+                            "sensitivity": "internal",
+                            "dimensions": [
+                                "event_id",
+                                "anime_title",
+                                "watched_at",
+                            ],
+                        },
+                    }
+                ],
+            }
+        )
+
+    def test_replace_mode_rollback_keeps_previous_rows_when_publish_insert_fails(self):
+        config = self._watch_events_config(publish_mode="replace")
+        builder = DataAssetBuilder(self.publish_database, self.state_root)
+        semantic_path = self.root / "semantic.yml"
+        [first] = builder.build_all(config, semantic_path)
+        self.assertEqual(first.status, "success")
+        self.assertEqual(first.published_rows, 2)
+        # Feed a brand-new key so replace mode actually drops and re-inserts.
+        self.csv_path.write_text(
+            "\n".join(
+                [
+                    "Event ID,Anime Title,Watched At,Watch Seconds",
+                    "1,Azure Voyager,2024-01-01,10.5",
+                    "3,Crimson Horizon,2024-01-04,13",
+                    "5,Neon Chronicle,2024-01-05,14",
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        real_connect = sqlite3.connect
+
+        def failing_connect(database, *args, **kwargs):
+            connection = real_connect(
+                database, *args, factory=_FailingExecutemanyConnection, **kwargs
+            )
+            connection._failing_sql = 'INSERT INTO "fact_watch_events"'
+            return connection
+
+        with patch("sqlite3.connect", side_effect=failing_connect):
+            [second] = builder.build_all(config, semantic_path)
+        self.assertEqual(second.status, "failed")
+        self.assertIn("injected failure", second.error or "")
+        # The pre-build table and rows survived the in-transaction ROLLBACK and
+        # the batch-level checkpoint restore.
+        with sqlite3.connect(self.publish_database) as connection:
+            self.assertEqual(
+                connection.execute(
+                    "SELECT event_id FROM fact_watch_events ORDER BY event_id"
+                ).fetchall(),
+                [(1,), (3,)],
+            )
+        with sqlite3.connect(builder.metadata_database) as connection:
+            failed_rows = connection.execute(
+                "SELECT COUNT(*) FROM asset_lineage "
+                "WHERE run_id = ? AND status = 'failed'",
+                (second.run_id,),
+            ).fetchone()[0]
+            self.assertGreaterEqual(failed_rows, 1)
+
+    def test_checkpoint_restore_with_wal_is_consistent(self):
+        builder = DataAssetBuilder(self.publish_database, self.state_root)
+        with sqlite3.connect(self.publish_database) as connection:
+            connection.execute("PRAGMA journal_mode=WAL")
+            connection.execute("CREATE TABLE fact_events (id INTEGER, name TEXT)")
+            connection.executemany(
+                "INSERT INTO fact_events VALUES (?, ?)", [(1, "a"), (2, "b")]
+            )
+        # A successful build on the WAL database exercises the checkpoint backup
+        # against a WAL-mode source.
+        [result] = builder.build_all(self._watch_events_config())
+        self.assertEqual(result.status, "success")
+        with sqlite3.connect(self.publish_database) as connection:
+            self.assertEqual(
+                connection.execute("SELECT COUNT(*) FROM fact_events").fetchone()[0],
+                2,
+            )
+        checkpoint = builder._create_publication_checkpoint()
+        # Post-checkpoint WAL writes plus a schema change must vanish on restore.
+        with sqlite3.connect(self.publish_database) as connection:
+            connection.execute("INSERT INTO fact_events VALUES (3, 'c')")
+            connection.execute("ALTER TABLE fact_events ADD COLUMN extra TEXT")
+        builder._restore_publication_checkpoint(checkpoint)
+        self.assertFalse(Path(str(self.publish_database) + "-wal").exists())
+        self.assertFalse(Path(str(self.publish_database) + "-shm").exists())
+        with sqlite3.connect(self.publish_database) as connection:
+            self.assertEqual(
+                connection.execute(
+                    "SELECT id, name FROM fact_events ORDER BY id"
+                ).fetchall(),
+                [(1, "a"), (2, "b")],
+            )
+            columns = [
+                row[1]
+                for row in connection.execute("PRAGMA table_info(fact_events)")
+            ]
+            self.assertEqual(columns, ["id", "name"])
+
+    @unittest.skipIf(fcntl is None, "fcntl not available on this platform")
+    def test_concurrent_builder_fails_fast_while_lock_is_held(self):
+        builder = DataAssetBuilder(self.publish_database, self.state_root)
+        lock_path = self.publish_database.with_name(
+            self.publish_database.name + ".lock"
+        )
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        handle = open(lock_path, "a+")
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            with self.assertRaisesRegex(DataAssetError, "concurrent builders"):
+                builder.build_all(self._watch_events_config())
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+            handle.close()
+
+    def test_replace_mode_drop_is_rolled_back_when_insert_phase_fails(self):
+        builder = DataAssetBuilder(self.publish_database, self.state_root)
+        with sqlite3.connect(self.publish_database) as connection:
+            connection.execute("CREATE TABLE fact_events (id INTEGER)")
+            connection.executemany(
+                "INSERT INTO fact_events(id) VALUES (?)", [(1,), (2,)]
+            )
+        with patch(
+            "queryforge.data_assets.pipeline._infer_types",
+            side_effect=DataAssetError("injected failure between DROP and INSERT"),
+        ):
+            with self.assertRaises(DataAssetError):
+                builder._publish("fact_events", [{"id": 3}], "replace")
+        with sqlite3.connect(self.publish_database) as connection:
+            self.assertEqual(
+                connection.execute(
+                    "SELECT id FROM fact_events ORDER BY id"
+                ).fetchall(),
+                [(1,), (2,)],
+            )
 
     def test_csv_pipeline_quarantines_invalid_rows_tracks_watermark_and_publishes_semantics(self):
         config = AssetBuildConfig.model_validate(

--- a/tests/test_evaluate_sql.py
+++ b/tests/test_evaluate_sql.py
@@ -2,8 +2,10 @@ import importlib.util
 import json
 import sqlite3
 import tempfile
+import time
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
@@ -31,6 +33,51 @@ class FakeService:
                 "candidates": [{"sql": "SELECT 2"}, {"sql": "SELECT 1"}],
             },
         }
+
+
+class BlockedService:
+    """Query case whose generated SQL was (wrongly) rejected by the policy engine."""
+
+    def ask(self, question, options):
+        return {
+            "status": "blocked",
+            "rows": [],
+            "sql": "SELECT secret FROM numbers",
+            "sql_security": {
+                "decisions": [
+                    {
+                        "allowed": False,
+                        "run_id": "qf_blocked",
+                        "policy_name": "strict",
+                        "rule": "column_scope",
+                        "reason": "outside the allowed column scope",
+                    }
+                ]
+            },
+        }
+
+
+class ReorderedService:
+    """Model returns correct rows but with a different column order."""
+
+    def ask(self, question, options):
+        return {
+            "status": "success",
+            "rows": [[2, 1]],
+            "columns": ["b", "a"],
+            "sql": "SELECT b, a FROM pairs",
+            "model_provider": "fake",
+            "model": "fake-model",
+        }
+
+
+class WarmupService:
+    def ask(self, question, options):
+        if question == "warmup":
+            time.sleep(0.25)
+            return {"status": "success", "rows": [[1]], "sql": "SELECT 1"}
+        time.sleep(0.02)
+        return {"status": "success", "rows": [[1]], "sql": "SELECT 1"}
 
 
 class EvaluateSqlTest(unittest.TestCase):
@@ -99,6 +146,158 @@ class EvaluateSqlTest(unittest.TestCase):
         self.assertEqual(metrics["candidate_selection_uplift"], 1.0)
         self.assertGreater(metrics["average_estimated_cost_usd"], 0)
         self.assertIsNotNone(metrics["p50_latency_ms"])
+        self.assertEqual(report["query_count"], 1)
+        self.assertEqual(report["probe_count"], 1)
+        self.assertEqual(metrics["policy_true_positives"], 1)
+        self.assertEqual(metrics["policy_false_positives"], 0)
+        self.assertEqual(metrics["policy_false_negatives"], 0)
+
+    def _query_case(self, database: str, **extra) -> dict:
+        case = {
+            "id": "query_1",
+            "domain": "test",
+            "category": "metric",
+            "expected_outcome": "query",
+            "question": "return one",
+            "expected_sql": "SELECT 1",
+        }
+        case["database"] = database
+        case.update(extra)
+        return case
+
+    def _probe_case(self, database: str, probe: str, sql_policy: str | None = None) -> dict:
+        case = {
+            "id": "reject_1",
+            "domain": "test",
+            "category": "policy_rejection",
+            "expected_outcome": "policy_rejection",
+            "question": "delete",
+            "database": database,
+            "policy_probe_sql": probe,
+        }
+        if sql_policy:
+            case["sql_policy"] = sql_policy
+        return case
+
+    def _run(
+        self, service, cases, database: Path, environment_root: Path
+    ) -> dict:
+        return evaluate_sql.evaluate_cases(
+            cases,
+            service=service,
+            environment=evaluate_sql.EvaluationEnvironment(environment_root),
+            default_database=str(database),
+        )
+
+    def test_probes_run_through_the_real_policy_engine_with_case_policy(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            database = root / "numbers.sqlite"
+            with sqlite3.connect(database) as connection:
+                connection.execute("CREATE TABLE numbers (value INTEGER)")
+                connection.execute("INSERT INTO numbers VALUES (1)")
+            scope_policy = root / "scope.yml"
+            scope_policy.write_text(
+                "version: 1\nname: scope\nallowed_tables: []\n",
+                encoding="utf-8",
+            )
+            open_policy = root / "open.yml"
+            open_policy.write_text(
+                "version: 1\nname: open\nallowed_tables: [numbers]\n",
+                encoding="utf-8",
+            )
+            cases = [
+                # Table-scope probe must be rejected by the real engine.
+                self._probe_case(
+                    str(database),
+                    "SELECT value FROM numbers",
+                    sql_policy=str(scope_policy),
+                ),
+                # A probe that the policy allows is a bypass -> false negative.
+                self._probe_case(
+                    str(database),
+                    "SELECT 1",
+                    sql_policy=str(open_policy),
+                ),
+            ]
+            report = self._run(FakeService(), cases, database, root / "assets")
+        metrics = report["metrics"]
+        self.assertEqual(metrics["policy_true_positives"], 1)
+        self.assertEqual(metrics["policy_false_negatives"], 1)
+        self.assertEqual(metrics["policy_rejection_recall"], 0.5)
+        probe = report["results"][0]
+        self.assertEqual(probe["policy_rule"], "table_scope")
+        self.assertEqual(probe["policy_name"], "scope")
+
+    def test_query_case_policy_rejection_counts_as_false_positive(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            database = root / "numbers.sqlite"
+            with sqlite3.connect(database) as connection:
+                connection.execute("CREATE TABLE numbers (value INTEGER)")
+                connection.execute("INSERT INTO numbers VALUES (1)")
+            cases = [
+                self._query_case(str(database)),
+                self._probe_case(str(database), "DELETE FROM numbers"),
+            ]
+            report = self._run(
+                BlockedService(), cases, database, root / "assets"
+            )
+        metrics = report["metrics"]
+        # TP=1 (probe), FP=1 (legitimate query wrongly rejected) -> precision 0.5.
+        self.assertEqual(metrics["policy_false_positives"], 1)
+        self.assertEqual(metrics["policy_rejection_precision"], 0.5)
+        self.assertEqual(metrics["policy_rejection_recall"], 1.0)
+
+    def test_semantic_equivalence_is_tolerant_to_column_order(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            database = root / "pairs.sqlite"
+            with sqlite3.connect(database) as connection:
+                connection.execute("CREATE TABLE pairs (a INTEGER, b INTEGER)")
+                connection.execute("INSERT INTO pairs VALUES (1, 2)")
+            case = self._query_case(str(database))
+            case["expected_sql"] = "SELECT a, b FROM pairs"
+            report = self._run(
+                ReorderedService(), [case], database, root / "assets"
+            )
+        self.assertEqual(report["metrics"]["semantic_correctness_rate"], 1.0)
+
+    def test_followup_warmup_turns_are_excluded_from_latency(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            database = root / "numbers.sqlite"
+            with sqlite3.connect(database) as connection:
+                connection.execute("CREATE TABLE numbers (value INTEGER)")
+                connection.execute("INSERT INTO numbers VALUES (1)")
+            case = self._query_case(str(database))
+            case["follow_up_context"] = ["warmup"]
+            report = self._run(
+                WarmupService(), [case], database, root / "assets"
+            )
+        latency = report["results"][0]["latency_ms"]
+        self.assertLess(latency, 200, "latency must exclude the 250ms warmup turn")
+
+    def test_gate_failures_only_apply_to_measurable_cases(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            database = root / "numbers.sqlite"
+            with sqlite3.connect(database) as connection:
+                connection.execute("CREATE TABLE numbers (value INTEGER)")
+            # A probe the default policy allows -> recall 0.0 (bypass).
+            cases = [self._probe_case(str(database), "SELECT 1")]
+            report = self._run(FakeService(), cases, database, root / "assets")
+        self.assertIsNone(report["metrics"]["sql_execution_success_rate"])
+        self.assertEqual(report["metrics"]["policy_rejection_recall"], 0.0)
+        # Probe-only runs must not trip the execution-success gate.
+        with patch("sys.argv", ["evaluate_sql.py", "--cases", "x.jsonl"]):
+            args = evaluate_sql.parse_args()
+        self.assertEqual(evaluate_sql._gate_failures(report, args), [])
+        args.min_policy_recall = 1.0
+        self.assertEqual(
+            evaluate_sql._gate_failures(report, args),
+            ["policy_rejection_recall=0.0 below --min-policy-recall 1.0"],
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_report_artifact.py
+++ b/tests/test_report_artifact.py
@@ -99,6 +99,22 @@ class ReportArtifactTest(unittest.TestCase):
         chart = next(section for section in artifact.sections if section.type == "chart")
         self.assertEqual(chart.content["chart_type"], "line")
 
+    def test_chart_spec_escapes_script_breakout(self):
+        payload = "</script><script>alert(1)</script>"
+        artifact = ReportGenerator(self.root / "reports").generate(
+            self.context(
+                columns=["category", "total"],
+                rows=[[payload, 10], ["music", 5]],
+            )
+        )
+        html = Path(artifact.file_path).read_text(encoding="utf-8")
+        self.assertIn("vegaEmbed", html)
+        # The user-controlled value must never terminate the enclosing script tag.
+        self.assertNotIn("</script><script>", html)
+        self.assertIn("<\\/script><script>", html)
+        # The regular HTML table context remains entity-escaped.
+        self.assertIn("&lt;/script&gt;", html)
+
     def test_generator_uses_metric_cards_for_scalar_result(self):
         artifact = ReportGenerator(self.root / "reports").generate(
             self.context(columns=["total"], rows=[[35]])

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -121,16 +121,81 @@ class StreamingTest(unittest.TestCase):
         self.assertIn("phase_completed", event_types)
         self.assertIn("artifact_created", event_types)
         self.assertEqual(event_types[-1], "final_result")
+        terminal = events[-1]
+        self.assertEqual(terminal.result["rows"], [["alpha"]])
+        self.assertIsNone(terminal.error)
+        # Progress events never leak SQL or rows; only the terminal event carries
+        # the serialized answer.
         serialized = json.dumps(
-            [event.model_dump(mode="json") for event in events],
+            [event.model_dump(mode="json") for event in events[:-1]],
             ensure_ascii=False,
         )
         self.assertNotIn("SELECT", serialized)
         self.assertNotIn("alpha", serialized)
         self.assertNotIn("rows", serialized)
 
+    def test_stream_cancel_stops_workflow_and_reports_cancelled(self):
+        import threading
+
+        class BlockingLLM:
+            def __init__(self) -> None:
+                self.release = threading.Event()
+
+            def generate_json(self, prompt: str) -> dict:
+                self.release.wait(timeout=15)
+                return {"skills": [], "reason": "No optional skill."}
+
+        blocking = BlockingLLM()
+        service = AgentService(
+            config_loader=lambda **_: self.config,
+            llm_factory=lambda _: blocking,
+        )
+        event_stream = service.stream(
+            "List item names",
+            self.options("stream_cancel"),
+        )
+        first = next(event_stream)
+        self.assertEqual(first.event_type, "run_started")
+        event_stream.cancel()
+        blocking.release.set()
+        events = [first, *event_stream]
+        terminal = events[-1]
+        self.assertEqual(terminal.event_type, "final_result")
+        self.assertEqual(terminal.status, "cancelled")
+        self.assertEqual(terminal.result["status"], "cancelled")
+        self.assertIsNone(event_stream.error)
+        self.assertEqual(event_stream.result["status"], "cancelled")
+
+    def test_event_stream_queue_is_bounded_and_terminal_is_never_dropped(self):
+        from queryforge.application.event_stream import WorkflowEventStream
+
+        emitter = EventEmitter(buffer_size=2)
+        stream = WorkflowEventStream(emitter, queue_maxsize=2)
+        for index in range(5):
+            stream._publish(
+                WorkflowEvent(
+                    event_type="node_started",
+                    run_id="qf_bounded",
+                    node_name=f"node_{index}",
+                )
+            )
+        stream._publish(
+            WorkflowEvent(
+                event_type="final_result",
+                run_id="qf_bounded",
+                status="success",
+                result={"status": "success", "rows": [["kept"]]},
+            )
+        )
+        stream._close()
+        events = list(stream)
+        self.assertEqual(events[-1].event_type, "final_result")
+        self.assertEqual(events[-1].result["rows"], [["kept"]])
+        # Progress events may be dropped, but the queue never grew unbounded.
+        self.assertLessEqual(len(events), 3)
+
     @unittest.skipUnless(FASTAPI_AVAILABLE, "optional FastAPI dependencies not installed")
-    def test_api_sse_returns_progress_only_events(self):
+    def test_api_sse_delivers_progress_then_terminal_result(self):
         from fastapi.testclient import TestClient
 
         response = TestClient(create_app(self.service())).post(
@@ -150,8 +215,11 @@ class StreamingTest(unittest.TestCase):
         ]
         self.assertEqual(payloads[0]["event_type"], "run_started")
         self.assertEqual(payloads[-1]["event_type"], "final_result")
-        self.assertNotIn("rows", response.text)
-        self.assertNotIn("SELECT", response.text)
+        # Progress events stay clean; the terminal event carries the answer.
+        progress_text = json.dumps(payloads[:-1], ensure_ascii=False)
+        self.assertNotIn("rows", progress_text)
+        self.assertNotIn("SELECT", progress_text)
+        self.assertEqual(payloads[-1]["result"]["rows"], [["alpha"]])
 
     def test_cli_stream_writes_progress_to_stderr_and_json_to_stdout(self):
         class FakeStream:

--- a/tests/test_transport_security.py
+++ b/tests/test_transport_security.py
@@ -1,0 +1,225 @@
+"""Offline tests for transport hardening: API-key auth and path allowlists."""
+
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+import tempfile
+import unittest
+from dataclasses import replace
+from pathlib import Path
+
+from queryforge.application import AgentOptions, AgentService
+from queryforge.core.config import Config
+from queryforge.interfaces.transport_security import (
+    database_roots,
+    report_roots,
+    request_api_key_matches,
+    validate_transport_options,
+)
+
+FASTAPI_AVAILABLE = importlib.util.find_spec("fastapi") is not None
+
+
+class TransportLLM:
+    def generate_json(self, prompt: str) -> dict:
+        if "Select local QueryForge skills" in prompt:
+            return {"skills": [], "reason": "No optional skill."}
+        if "Evaluate whether the SQL and result" in prompt:
+            return {
+                "success": True,
+                "strategy": "SUCCESS",
+                "reason": "The result answers the question.",
+                "suggested_fix": None,
+            }
+        return {
+            "sql": "SELECT name FROM items ORDER BY name",
+            "explanation": "List names.",
+            "tables_used": ["items"],
+        }
+
+
+class TransportSecurityTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.directory = tempfile.TemporaryDirectory()
+        self.root = Path(self.directory.name)
+        self.database = self.root / "items.sqlite"
+        connection = sqlite3.connect(self.database)
+        connection.execute("CREATE TABLE items (name TEXT)")
+        connection.executemany("INSERT INTO items VALUES (?)", [("a",), ("b",)])
+        connection.commit()
+        connection.close()
+        # A second, unrelated directory tree that must never be reachable.
+        self.outside_directory = tempfile.TemporaryDirectory()
+        self.outside_root = Path(self.outside_directory.name)
+        self.outside = self.outside_root / "secret.sqlite"
+        connection = sqlite3.connect(self.outside)
+        connection.execute("CREATE TABLE items (name TEXT)")
+        connection.execute("INSERT INTO items VALUES ('secret')")
+        connection.commit()
+        connection.close()
+        self.config = Config(
+            llm_provider="openai",
+            llm_api_key=None,
+            llm_model="offline",
+            llm_base_url=None,
+            database_path=str(self.database),
+            history_db_path=str(self.root / "history.sqlite"),
+            orchestration_state_root=str(self.root / "runs"),
+            report_output_dir=str(self.root / "reports"),
+        )
+
+    def tearDown(self) -> None:
+        self.directory.cleanup()
+        self.outside_directory.cleanup()
+
+    def service(self, config: Config | None = None) -> AgentService:
+        return AgentService(
+            config_loader=lambda **_: config or self.config,
+            llm_factory=lambda _: TransportLLM(),
+        )
+
+    def test_api_key_match_is_disabled_without_configured_key(self):
+        self.assertTrue(request_api_key_matches(self.config, None, None))
+
+    def test_api_key_match_accepts_bearer_and_x_api_key_constant_time(self):
+        config = replace(self.config, api_key="secret-token")
+        self.assertTrue(
+            request_api_key_matches(config, "Bearer secret-token", None)
+        )
+        self.assertTrue(request_api_key_matches(config, None, "secret-token"))
+        self.assertFalse(request_api_key_matches(config, "Bearer wrong", None))
+        self.assertFalse(request_api_key_matches(config, None, "wrong"))
+        self.assertFalse(request_api_key_matches(config, None, None))
+
+    def test_database_roots_use_file_parents_and_directory_entries(self):
+        config = replace(
+            self.config,
+            allowed_database_paths=(str(self.database), str(self.root / "warehouse")),
+        )
+        roots = database_roots(config)
+        self.assertIn(self.database.parent.resolve(), roots)
+        self.assertIn((self.root / "warehouse").resolve(), roots)
+
+    def test_network_entrypoint_rejects_database_outside_roots(self):
+        with self.assertRaisesRegex(ValueError, "outside the allowed transport paths"):
+            self.service().ask(
+                "List names",
+                AgentOptions(
+                    database=str(self.outside),
+                    skills=[],
+                    entrypoint="api",
+                    run_id="qf_network_block",
+                    orchestration_state_root=str(self.root / "runs"),
+                ),
+            )
+
+    def test_cli_entrypoint_remains_unrestricted(self):
+        answer = self.service().ask(
+            "List names",
+            AgentOptions(
+                database=str(self.outside),
+                skills=[],
+                entrypoint="cli",
+                run_id="qf_cli_local",
+                orchestration_state_root=str(self.root / "runs"),
+            ),
+        )
+        self.assertEqual(answer["status"], "success")
+        self.assertEqual(answer["rows"], [["secret"]])
+
+    def test_configured_allowlist_replaces_fallback_roots(self):
+        allowed = self.root / "allowed"
+        allowed.mkdir()
+        allowed_database = allowed / "data.sqlite"
+        connection = sqlite3.connect(allowed_database)
+        connection.execute("CREATE TABLE items (name TEXT)")
+        connection.execute("INSERT INTO items VALUES ('in')")
+        connection.commit()
+        connection.close()
+        config = replace(
+            self.config,
+            allowed_database_paths=(str(allowed),),
+        )
+        answer = self.service(config).ask(
+            "List names",
+            AgentOptions(
+                database=str(allowed_database),
+                skills=[],
+                entrypoint="api",
+                run_id="qf_allowlisted",
+                orchestration_state_root=str(self.root / "runs"),
+            ),
+        )
+        self.assertEqual(answer["rows"], [["in"]])
+        with self.assertRaisesRegex(ValueError, "outside the allowed transport paths"):
+            self.service(config).ask(
+                "List names",
+                AgentOptions(
+                    database=str(self.outside),
+                    skills=[],
+                    entrypoint="api",
+                    run_id="qf_allowlisted_block",
+                    orchestration_state_root=str(self.root / "runs"),
+                ),
+            )
+
+    def test_network_entrypoint_confines_report_output_dir(self):
+        options = AgentOptions(
+            database=str(self.database),
+            skills=[],
+            entrypoint="api",
+            run_id="qf_report_block",
+            orchestration_state_root=str(self.root / "runs"),
+            report_output_dir=str(self.root / "elsewhere"),
+        )
+        with self.assertRaisesRegex(ValueError, "outside the allowed transport paths"):
+            self.service().ask("List names", options)
+
+    def test_report_path_rejects_roots_outside_allowlist(self):
+        service = self.service()
+        with self.assertRaisesRegex(ValueError, "outside the allowed transport paths"):
+            service.report_path(
+                "qf_missing_report",
+                report_output_dir=str(self.root / "elsewhere"),
+            )
+
+    def test_validate_transport_options_checks_auxiliary_paths(self):
+        config = self.config
+        outside_policy = self.outside_root / "policy.yml"
+        with self.assertRaisesRegex(ValueError, "sql_policy_path"):
+            validate_transport_options(
+                config,
+                AgentOptions(
+                    database=str(self.database),
+                    sql_policy_path=str(outside_policy),
+                    entrypoint="mcp",
+                ),
+            )
+
+    def test_report_roots_default_to_configured_output_dir(self):
+        self.assertEqual(report_roots(self.config), ((self.root / "reports").resolve(),))
+
+    @unittest.skipUnless(FASTAPI_AVAILABLE, "optional FastAPI dependencies not installed")
+    def test_fastapi_requires_api_key_when_configured(self):
+        from fastapi.testclient import TestClient
+
+        from queryforge.interfaces.api.app import create_app
+
+        secured = replace(self.config, api_key="app-secret")
+        client = TestClient(create_app(self.service(secured)))
+        self.assertEqual(client.get("/health").status_code, 200)
+        blocked = client.post(
+            "/ask", json={"question": "List names", "database": str(self.database)}
+        )
+        self.assertEqual(blocked.status_code, 401)
+        allowed = client.post(
+            "/ask",
+            headers={"X-API-Key": "app-secret"},
+            json={"question": "List names", "database": str(self.database)},
+        )
+        self.assertEqual(allowed.status_code, 200)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/app/api/queryforge/[...path]/route.ts
+++ b/web/app/api/queryforge/[...path]/route.ts
@@ -1,3 +1,5 @@
+import { requireStudioUser } from "@/app/studio-auth";
+
 const ALLOWED_PATHS = new Set([
   "health",
   "models",
@@ -22,12 +24,18 @@ async function proxy(
   request: Request,
   context: { params: Promise<{ path: string[] }> },
 ) {
+  const { response } = requireStudioUser(request);
+  if (response) return response;
   try {
     const { path } = await context.params;
     const target = backendUrl(path);
     const headers = new Headers();
     const contentType = request.headers.get("content-type");
     if (contentType) headers.set("content-type", contentType);
+    const authorization = request.headers.get("authorization");
+    if (authorization) headers.set("authorization", authorization);
+    const apiKey = request.headers.get("x-api-key");
+    if (apiKey) headers.set("x-api-key", apiKey);
 
     const upstream = await fetch(target, {
       method: request.method,

--- a/web/app/api/studio/domains/route.ts
+++ b/web/app/api/studio/domains/route.ts
@@ -1,3 +1,4 @@
+import { requireStudioUser } from "@/app/studio-auth";
 import { ensureStudioSchema, getStudioBindings } from "@/db/runtime";
 
 function slugify(value: string) {
@@ -9,8 +10,10 @@ function slugify(value: string) {
     .slice(0, 48);
 }
 
-export async function GET() {
+export async function GET(request: Request) {
   try {
+    const { response } = requireStudioUser(request);
+    if (response) return response;
     const { db } = getStudioBindings();
     await ensureStudioSchema(db);
     const result = await db
@@ -49,10 +52,13 @@ export async function GET() {
 
 export async function POST(request: Request) {
   try {
+    const auth = requireStudioUser(request);
+    if (auth.response) return auth.response;
     const payload = (await request.json()) as {
       name?: string;
       description?: string;
       owner?: string;
+      ownerEmail?: string;
     };
     const name = payload.name?.trim() ?? "";
     if (name.length < 2 || name.length > 80) {
@@ -70,7 +76,8 @@ export async function POST(request: Request) {
     const description =
       payload.description?.trim() ||
       "A governed data domain for source ingestion, semantic modeling, and trusted analysis.";
-    const owner = payload.owner?.trim() || "Workspace admin";
+    const owner =
+      payload.owner?.trim() || payload.ownerEmail?.trim() || "Workspace admin";
 
     await db
       .prepare(

--- a/web/app/api/studio/runs/route.ts
+++ b/web/app/api/studio/runs/route.ts
@@ -1,20 +1,48 @@
+import { requireStudioUser } from "@/app/studio-auth";
 import { ensureStudioSchema, getStudioBindings } from "@/db/runtime";
+
+const RUN_STATUSES = new Set([
+  "success",
+  "failed",
+  "blocked",
+  "cancelled",
+  "planned",
+]);
+const RUN_ID_PATTERN =
+  /^(qf_[a-f0-9]{32}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i;
+const MAX_QUESTION_LENGTH = 8000;
+const MAX_MODEL_LENGTH = 200;
+const MAX_DURATION_LENGTH = 100;
+const MAX_ID_LENGTH = 64;
 
 export async function GET(request: Request) {
   try {
-    const domainId = new URL(request.url).searchParams.get("domain_id");
+    const { response } = requireStudioUser(request);
+    if (response) return response;
+    const url = new URL(request.url);
+    const domainId = url.searchParams.get("domain_id");
+    const includeDemo = url.searchParams.get("include_demo") === "1";
     const { db } = getStudioBindings();
     await ensureStudioSchema(db);
+    const conditions: string[] = [];
+    const params: string[] = [];
+    if (domainId) {
+      conditions.push("domain_id = ?");
+      params.push(domainId);
+    }
+    if (!includeDemo) {
+      conditions.push("is_demo = 0");
+    }
+    const where = conditions.length ? ` WHERE ${conditions.join(" AND ")}` : "";
     const statement = db.prepare(
       `SELECT id, domain_id, question, status, model, row_count, duration,
               created_at
-       FROM studio_runs
-       ${domainId ? "WHERE domain_id = ?" : ""}
+       FROM studio_runs${where}
        ORDER BY created_at DESC
        LIMIT 50`,
     );
-    const result = domainId
-      ? await statement.bind(domainId).all()
+    const result = params.length
+      ? await statement.bind(...params).all()
       : await statement.all();
     return Response.json({ runs: result.results });
   } catch (error) {
@@ -31,6 +59,8 @@ export async function GET(request: Request) {
 
 export async function POST(request: Request) {
   try {
+    const { response } = requireStudioUser(request);
+    if (response) return response;
     const payload = (await request.json()) as {
       id?: string;
       domainId?: string;
@@ -39,32 +69,93 @@ export async function POST(request: Request) {
       model?: string;
       rowCount?: number;
       duration?: string;
+      isDemo?: boolean;
     };
-    if (!payload.id || !payload.domainId || !payload.question) {
+    const domainId = payload.domainId?.trim() ?? "";
+    const question = payload.question?.trim() ?? "";
+    if (!domainId || !question) {
       return Response.json(
-        { detail: "Run id, data domain, and question are required." },
+        { detail: "Run data domain and question are required." },
         { status: 400 },
       );
     }
+    const status = payload.status ?? "";
+    if (!RUN_STATUSES.has(status)) {
+      return Response.json(
+        {
+          detail: `Run status must be one of: ${[...RUN_STATUSES].join(", ")}.`,
+        },
+        { status: 400 },
+      );
+    }
+    if (question.length > MAX_QUESTION_LENGTH) {
+      return Response.json(
+        { detail: `Question exceeds the ${MAX_QUESTION_LENGTH} character limit.` },
+        { status: 400 },
+      );
+    }
+    const model = payload.model?.trim() ?? "configured model";
+    const duration = payload.duration?.trim() ?? "live";
+    if (model.length > MAX_MODEL_LENGTH) {
+      return Response.json(
+        { detail: `Model exceeds the ${MAX_MODEL_LENGTH} character limit.` },
+        { status: 400 },
+      );
+    }
+    if (duration.length > MAX_DURATION_LENGTH) {
+      return Response.json(
+        { detail: `Duration exceeds the ${MAX_DURATION_LENGTH} character limit.` },
+        { status: 400 },
+      );
+    }
+
+    let id = payload.id?.trim() ?? "";
+    if (id) {
+      if (id.length > MAX_ID_LENGTH || !RUN_ID_PATTERN.test(id)) {
+        return Response.json(
+          {
+            detail:
+              "Run id must be a qf_ identifier (qf_ followed by 32 hex digits) or a UUID.",
+          },
+          { status: 400 },
+        );
+      }
+    } else {
+      id = crypto.randomUUID();
+    }
+
     const { db } = getStudioBindings();
     await ensureStudioSchema(db);
+    const domain = await db
+      .prepare("SELECT id FROM studio_domains WHERE id = ? LIMIT 1")
+      .bind(domainId)
+      .first<{ id: string }>();
+    if (!domain) {
+      return Response.json(
+        { detail: "The data domain for this run does not exist." },
+        { status: 404 },
+      );
+    }
+
     await db
       .prepare(
-        `INSERT OR REPLACE INTO studio_runs (
-          id, domain_id, question, status, model, row_count, duration
-        ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        `INSERT INTO studio_runs (
+          id, domain_id, question, status, model, row_count, duration, is_demo
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(id) DO NOTHING`,
       )
       .bind(
-        payload.id,
-        payload.domainId,
-        payload.question,
-        payload.status ?? "Passed",
-        payload.model ?? "configured model",
+        id,
+        domainId,
+        question,
+        status,
+        model,
         payload.rowCount ?? 0,
-        payload.duration ?? "live",
+        duration,
+        payload.isDemo === true ? 1 : 0,
       )
       .run();
-    return Response.json({ status: "saved", id: payload.id }, { status: 201 });
+    return Response.json({ status: "saved", id }, { status: 201 });
   } catch (error) {
     return Response.json(
       {

--- a/web/app/api/studio/upload/route.ts
+++ b/web/app/api/studio/upload/route.ts
@@ -1,7 +1,9 @@
+import { requireStudioUser, studioAuthMode } from "@/app/studio-auth";
 import { ensureStudioSchema, getStudioBindings } from "@/db/runtime";
 
 const MAX_FILE_BYTES = 25 * 1024 * 1024;
 const ALLOWED_EXTENSIONS = new Set(["sqlite", "db", "csv", "parquet"]);
+const CSV_HEADER_READ_LIMIT = 256 * 1024;
 
 type UploadedSemanticContract = {
   version: number;
@@ -19,6 +21,26 @@ type UploadedSemanticContract = {
     expression: string;
   }>;
 };
+
+type FileValidation = {
+  file: string;
+  validation_status: "csv_headers_checked" | "not_verified_server_side";
+  missing_columns?: string[];
+  status?: "ok";
+};
+
+const SQL_EXPRESSION_KEYWORDS = new Set([
+  "select", "from", "where", "group", "by", "order", "having", "limit",
+  "offset", "as", "on", "and", "or", "not", "null", "is", "in", "between",
+  "like", "case", "when", "then", "else", "end", "distinct", "join", "left",
+  "right", "inner", "outer", "cross", "asc", "desc", "sum", "count", "avg",
+  "min", "max", "cast", "coalesce", "nullif", "if", "round", "abs", "floor",
+  "ceil", "over", "partition", "rows", "range", "unbounded", "preceding",
+  "following", "current", "row", "date", "datetime", "year", "month", "day",
+  "hour", "strftime", "true", "false", "substr", "replace", "trim", "lower",
+  "upper", "rank", "dense_rank", "row_number", "lag", "lead", "first_value",
+  "last_value",
+]);
 
 function safeFileName(name: string) {
   return name.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
@@ -80,8 +102,65 @@ function parseSemanticContract(value: FormDataEntryValue | null) {
   }
 }
 
+/** Bare `column` or `table.column` references inside a metric expression. */
+function referencedColumns(expression: string): string[] {
+  const found = new Set<string>();
+  const tokens =
+    expression.match(/[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?/g) ??
+    [];
+  for (const token of tokens) {
+    const parts = token.split(".");
+    const column = parts.length > 1 ? parts[parts.length - 1] : parts[0];
+    if (SQL_EXPRESSION_KEYWORDS.has(column.toLowerCase())) continue;
+    found.add(column);
+  }
+  return [...found];
+}
+
+function parseCsvHeaderLine(firstLine: string): string[] {
+  const cleaned = firstLine.replace(/^\uFEFF/, "").trim();
+  if (!cleaned) return [];
+  return cleaned
+    .split(",")
+    .map((cell) => cell.trim().replace(/^"([\s\S]*)"$/, "$1"));
+}
+
+/**
+ * Reads the first non-empty line of a CSV and checks that the columns named
+ * by the semantic contract (grain, primary key, dimensions, and any bare
+ * column references in metric expressions) exist in the header. Returns the
+ * list of missing columns (empty when every referenced column is present).
+ */
+async function validateCsvAgainstContract(
+  file: File,
+  contract: UploadedSemanticContract,
+): Promise<string[]> {
+  const sample = await file.slice(0, CSV_HEADER_READ_LIMIT).text();
+  const firstNonEmptyLine =
+    sample.split(/\r?\n/).find((line) => line.trim().length > 0) ?? "";
+  const header = parseCsvHeaderLine(firstNonEmptyLine);
+  const headerLookup = new Set(header.map((value) => value.toLowerCase()));
+  const missing = new Set<string>();
+  const requiredColumns = [
+    contract.grain,
+    contract.primaryKey,
+    ...contract.dimensions,
+  ].filter((value) => Boolean(value?.trim()));
+  for (const column of requiredColumns) {
+    if (!headerLookup.has(column.trim().toLowerCase())) missing.add(column);
+  }
+  for (const metric of contract.metrics) {
+    for (const column of referencedColumns(metric.expression)) {
+      if (!headerLookup.has(column.toLowerCase())) missing.add(column);
+    }
+  }
+  return [...missing];
+}
+
 export async function GET(request: Request) {
   try {
+    const { response } = requireStudioUser(request);
+    if (response) return response;
     const domainId = new URL(request.url).searchParams.get("domain_id");
     const { db } = getStudioBindings();
     await ensureStudioSchema(db);
@@ -111,6 +190,8 @@ export async function GET(request: Request) {
 
 export async function POST(request: Request) {
   try {
+    const auth = requireStudioUser(request);
+    if (auth.response) return auth.response;
     const form = await request.formData();
     const domainId = String(form.get("domain_id") ?? "").trim();
     if (!domainId) {
@@ -124,6 +205,28 @@ export async function POST(request: Request) {
         { detail: "A reviewed semantic contract is required." },
         { status: 400 },
       );
+    }
+    const reviewedBy = String(form.get("reviewed_by") ?? "").trim();
+    if (!reviewedBy) {
+      return Response.json(
+        {
+          detail:
+            "An accountable reviewer (reviewed_by) is required for every publication.",
+        },
+        { status: 400 },
+      );
+    }
+    if (studioAuthMode() === "chatgpt") {
+      const userEmail = auth.user?.email;
+      if (!userEmail || reviewedBy !== userEmail) {
+        return Response.json(
+          {
+            detail:
+              "reviewed_by must match the authenticated user's email.",
+          },
+          { status: 403 },
+        );
+      }
     }
     const semanticContract = parseSemanticContract(
       form.get("semantic_contract"),
@@ -178,6 +281,37 @@ export async function POST(request: Request) {
     const sourceId = crypto.randomUUID();
     const stored: Array<{ name: string; objectKey: string; size: number }> = [];
 
+    // Honest server-side validation: never fabricate an inference/contract
+    // verdict. CSV files get their header columns checked against the
+    // semantic contract; binary files can only be marked not-verified.
+    const fileValidations: FileValidation[] = [];
+    let allHeadersPass = true;
+    for (const file of files) {
+      if (extension(file.name) === "csv") {
+        const missingColumns = await validateCsvAgainstContract(
+          file,
+          semanticContract,
+        );
+        const validation: FileValidation = {
+          file: file.name,
+          validation_status: "csv_headers_checked",
+          missing_columns: missingColumns,
+        };
+        if (missingColumns.length === 0) {
+          validation.status = "ok";
+        } else {
+          allHeadersPass = false;
+        }
+        fileValidations.push(validation);
+      } else {
+        fileValidations.push({
+          file: file.name,
+          validation_status: "not_verified_server_side",
+        });
+        allHeadersPass = false;
+      }
+    }
+
     for (const file of files) {
       const objectKey = `domains/${domainId}/sources/${sourceId}/${safeFileName(file.name)}`;
       await uploads.put(objectKey, await file.arrayBuffer(), {
@@ -187,6 +321,7 @@ export async function POST(request: Request) {
           domainId,
           semanticEntity: semanticContract.entity,
           semanticReviewed: "true",
+          reviewedBy,
         },
       });
       stored.push({ name: file.name, objectKey, size: file.size });
@@ -200,15 +335,17 @@ export async function POST(request: Request) {
     const sourceType = Array.from(
       new Set(stored.map((file) => extension(file.name).toUpperCase())),
     ).join(" · ");
+    const contractStatus =
+      allHeadersPass && form.get("reviewed") === "true"
+        ? "reviewed"
+        : "review_pending";
+    const sourceStatus =
+      contractStatus === "reviewed" ? "ready" : "awaiting_validation";
     const semanticModel = {
       ...semanticContract,
-      reviewed: true,
       domain: { id: domainId, name: domain.name },
-      inference: {
-        status: "human_reviewed",
-        note: "Physical inference was confirmed by the accountable domain owner.",
-      },
-      contract: { status: "passed", blocking_failures: 0 },
+      review: { claimed: form.get("reviewed") === "true", reviewed_by: reviewedBy },
+      validation: { files: fileValidations },
     };
 
     await db
@@ -216,7 +353,7 @@ export async function POST(request: Request) {
         `INSERT INTO studio_sources (
           id, domain_id, name, source_type, object_key, size_bytes, table_count,
           status, semantic_json, reviewed, contract_status
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, 'ready', ?, 1, 'passed')`,
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       )
       .bind(
         sourceId,
@@ -226,7 +363,10 @@ export async function POST(request: Request) {
         stored[0].objectKey,
         totalBytes,
         stored.length,
+        sourceStatus,
         JSON.stringify(semanticModel),
+        contractStatus === "reviewed" ? 1 : 0,
+        contractStatus,
       )
       .run();
 
@@ -239,7 +379,8 @@ export async function POST(request: Request) {
           sourceType,
           sizeBytes: totalBytes,
           tableCount: stored.length,
-          status: "ready",
+          status: sourceStatus,
+          contractStatus,
           semanticModel,
         },
       },

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { headers } from "next/headers";
+import { getChatGPTUser } from "./chatgpt-auth";
 import "./globals.css";
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -56,14 +57,26 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const user = await getChatGPTUser();
+  const injectedUser = user
+    ? `window.__CHATGPT_USER__=${JSON.stringify({
+        email: user.email,
+        displayName: user.displayName,
+      }).replace(/</g, "\\u003c")};`
+    : "";
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        {injectedUser ? (
+          <script dangerouslySetInnerHTML={{ __html: injectedUser }} />
+        ) : null}
+        {children}
+      </body>
     </html>
   );
 }

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -605,6 +605,14 @@ function cn(...classes: Array<string | false | null | undefined>) {
   return classes.filter(Boolean).join(" ");
 }
 
+function chatgptUserEmail(): string | null {
+  if (typeof window === "undefined") return null;
+  const injected = (
+    window as unknown as { __CHATGPT_USER__?: { email?: string } }
+  ).__CHATGPT_USER__;
+  return injected && injected.email ? injected.email : null;
+}
+
 function Icon({ value }: { value: string }) {
   return (
     <span className="icon-glyph" aria-hidden="true">
@@ -764,7 +772,7 @@ export default function Home() {
           domainId: String(run.domain_id ?? SAMPLE_DOMAIN_ID),
           question: String(run.question),
           status:
-            String(run.status) === "Blocked"
+            String(run.status) === "blocked"
               ? ("Blocked" as const)
               : ("Passed" as const),
           model: String(run.model ?? "configured model"),
@@ -884,17 +892,23 @@ export default function Home() {
       },
       ...current.filter((item) => item.id !== nextResult.runId),
     ]);
+    const persistedRunId = /^(qf_[a-f0-9]{32}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i.test(
+      nextResult.runId,
+    )
+      ? nextResult.runId
+      : `qf_${crypto.randomUUID().replaceAll("-", "")}`;
     void fetch("/api/studio/runs", {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
-        id: nextResult.runId,
+        id: persistedRunId,
         domainId: activeDomain.id,
         question: submitted,
-        status: "Passed",
+        status: "success",
         model: connection === "live" ? "configured model" : "demo-model",
         rowCount: nextResult.rowCount,
         duration: connection === "live" ? "live" : "1.84s",
+        isDemo: connection !== "live",
       }),
     }).catch(() => undefined);
     setIsRunning(false);
@@ -987,6 +1001,10 @@ export default function Home() {
     uploadFiles.forEach((file) => payload.append("files", file));
     payload.append("domain_id", activeDomain.id);
     payload.append("reviewed", "true");
+    payload.append(
+      "reviewed_by",
+      chatgptUserEmail() ?? "local-workspace",
+    );
     payload.append(
       "semantic_contract",
       JSON.stringify({
@@ -1090,7 +1108,10 @@ export default function Home() {
       const response = await fetch("/api/studio/domains", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify(input),
+        body: JSON.stringify({
+          ...input,
+          ownerEmail: chatgptUserEmail() ?? undefined,
+        }),
       });
       if (response.ok) {
         const payload = (await response.json()) as { domain: DataDomain };

--- a/web/app/studio-auth.ts
+++ b/web/app/studio-auth.ts
@@ -1,0 +1,76 @@
+import type { ChatGPTUser } from "./chatgpt-auth";
+
+const USER_EMAIL_HEADER = "oai-authenticated-user-email";
+const USER_FULL_NAME_HEADER = "oai-authenticated-user-full-name";
+const USER_FULL_NAME_ENCODING_HEADER =
+  "oai-authenticated-user-full-name-encoding";
+const PERCENT_ENCODED_UTF8 = "percent-encoded-utf-8";
+
+export type StudioAuthMode = "off" | "chatgpt";
+
+/**
+ * Effective Studio auth mode, driven by the STUDIO_AUTH_MODE env var.
+ * `off` (default) keeps the current anonymous behavior; `chatgpt` requires
+ * an `oai-authenticated-user-*` header on every Studio/proxy request.
+ */
+export function studioAuthMode(): StudioAuthMode {
+  return process.env.STUDIO_AUTH_MODE === "chatgpt" ? "chatgpt" : "off";
+}
+
+/**
+ * Reads the ChatGPT-authenticated user from the incoming request headers.
+ * Returns null when no user header is present (regardless of auth mode).
+ */
+export function getStudioUser(request: Request): ChatGPTUser | null {
+  const email = request.headers.get(USER_EMAIL_HEADER);
+  if (!email) return null;
+
+  const encodedFullName = request.headers.get(USER_FULL_NAME_HEADER);
+  const fullName =
+    encodedFullName &&
+    request.headers.get(USER_FULL_NAME_ENCODING_HEADER) === PERCENT_ENCODED_UTF8
+      ? safeDecodeURIComponent(encodedFullName)
+      : null;
+
+  return {
+    displayName: fullName ?? email,
+    email,
+    fullName,
+  };
+}
+
+export type StudioAuthResult = {
+  user: ChatGPTUser | null;
+  response: Response | null;
+};
+
+/**
+ * Guards a Studio route handler. When STUDIO_AUTH_MODE is "chatgpt" and the
+ * request carries no authenticated user, returns a 401 JSON response that the
+ * handler must return immediately. When mode is "off" this never blocks and
+ * always returns a null response.
+ */
+export function requireStudioUser(request: Request): StudioAuthResult {
+  if (studioAuthMode() !== "chatgpt") {
+    return { user: null, response: null };
+  }
+  const user = getStudioUser(request);
+  if (!user) {
+    return {
+      user: null,
+      response: Response.json(
+        { detail: "Authentication required." },
+        { status: 401 },
+      ),
+    };
+  }
+  return { user, response: null };
+}
+
+function safeDecodeURIComponent(value: string): string | null {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return null;
+  }
+}

--- a/web/db/runtime.ts
+++ b/web/db/runtime.ts
@@ -65,6 +65,7 @@ export async function ensureStudioSchema(db: D1Database) {
         model TEXT NOT NULL,
         row_count INTEGER NOT NULL DEFAULT 0,
         duration TEXT NOT NULL,
+        is_demo INTEGER NOT NULL DEFAULT 0,
         created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
       )
     `),
@@ -83,6 +84,13 @@ export async function ensureStudioSchema(db: D1Database) {
     "domain_id",
     `ALTER TABLE studio_runs
      ADD COLUMN domain_id TEXT NOT NULL DEFAULT '${SAMPLE_DOMAIN_ID}'`,
+  );
+  await ensureColumn(
+    db,
+    "studio_runs",
+    "is_demo",
+    `ALTER TABLE studio_runs
+     ADD COLUMN is_demo INTEGER NOT NULL DEFAULT 0`,
   );
 
   await db.batch([

--- a/web/db/schema.ts
+++ b/web/db/schema.ts
@@ -64,6 +64,7 @@ export const studioRuns = sqliteTable(
     model: text("model").notNull(),
     rowCount: integer("row_count").notNull().default(0),
     duration: text("duration").notNull(),
+    isDemo: integer("is_demo", { mode: "boolean" }).notNull().default(false),
     createdAt: text("created_at").notNull().default(sql`CURRENT_TIMESTAMP`),
   },
   (table) => [

--- a/web/drizzle/0003_sleepy_terrax.sql
+++ b/web/drizzle/0003_sleepy_terrax.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `studio_runs` ADD `is_demo` integer DEFAULT false NOT NULL;

--- a/web/drizzle/meta/0003_snapshot.json
+++ b/web/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,319 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "41c778ef-8b8c-461c-9dd9-a78cf4c1a080",
+  "prevId": "55323f7a-ea49-403e-aa7a-856a33f77690",
+  "tables": {
+    "studio_domains": {
+      "name": "studio_domains",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Workspace admin'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "is_sample": {
+          "name": "is_sample",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "studio_domains_slug_idx": {
+          "name": "studio_domains_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "studio_domains_created_at_idx": {
+          "name": "studio_domains_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "studio_runs": {
+      "name": "studio_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'domain_anime_streaming'"
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "duration": {
+          "name": "duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_demo": {
+          "name": "is_demo",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "studio_runs_domain_id_idx": {
+          "name": "studio_runs_domain_id_idx",
+          "columns": [
+            "domain_id"
+          ],
+          "isUnique": false
+        },
+        "studio_runs_created_at_idx": {
+          "name": "studio_runs_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "studio_sources": {
+      "name": "studio_sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'domain_anime_streaming'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "table_count": {
+          "name": "table_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ready'"
+        },
+        "semantic_json": {
+          "name": "semantic_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reviewed": {
+          "name": "reviewed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "contract_status": {
+          "name": "contract_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "studio_sources_domain_id_idx": {
+          "name": "studio_sources_domain_id_idx",
+          "columns": [
+            "domain_id"
+          ],
+          "isUnique": false
+        },
+        "studio_sources_created_at_idx": {
+          "name": "studio_sources_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/web/drizzle/meta/_journal.json
+++ b/web/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1784885121869,
       "tag": "0002_brave_gamora",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1786713558184,
+      "tag": "0003_sleepy_terrax",
+      "breakpoints": true
     }
   ]
 }

--- a/web/tests/rendered-html.test.mjs
+++ b/web/tests/rendered-html.test.mjs
@@ -51,3 +51,54 @@ test("keeps domains isolated and semantic review mandatory", async () => {
   await access(new URL("../public/og.png", import.meta.url));
   await access(new URL("../public/favicon.png", import.meta.url));
 });
+
+test("hardens Studio run history and upload attribution", async () => {
+  const [page, uploadRoute, runsRoute, schema, runtime, studioAuth, proxyRoute] =
+    await Promise.all([
+      readFile(new URL("../app/page.tsx", import.meta.url), "utf8"),
+      readFile(
+        new URL("../app/api/studio/upload/route.ts", import.meta.url),
+        "utf8",
+      ),
+      readFile(
+        new URL("../app/api/studio/runs/route.ts", import.meta.url),
+        "utf8",
+      ),
+      readFile(new URL("../db/schema.ts", import.meta.url), "utf8"),
+      readFile(new URL("../db/runtime.ts", import.meta.url), "utf8"),
+      readFile(new URL("../app/studio-auth.ts", import.meta.url), "utf8"),
+      readFile(
+        new URL("../app/api/queryforge/[...path]/route.ts", import.meta.url),
+        "utf8",
+      ),
+    ]);
+
+  // Run persistence: never overwrite an existing run, mark demo runs.
+  assert.match(runsRoute, /ON CONFLICT\(id\) DO NOTHING/);
+  assert.match(runsRoute, /INSERT INTO studio_runs/);
+  assert.match(runsRoute, /is_demo/);
+  assert.match(runsRoute, /RUN_STATUSES/);
+  assert.match(runsRoute, /crypto\.randomUUID\(\)/);
+  assert.match(runsRoute, /include_demo/);
+  assert.match(schema, /is_demo/);
+  assert.match(runtime, /is_demo/);
+  assert.match(runtime, /ALTER TABLE studio_runs/);
+  assert.match(page, /isDemo/);
+  assert.match(page, /reviewed_by/);
+
+  // Upload attribution: no fabricated inference/contract verdicts.
+  assert.match(uploadRoute, /reviewed_by/);
+  assert.match(uploadRoute, /csv_headers_checked/);
+  assert.match(uploadRoute, /not_verified_server_side/);
+  assert.match(uploadRoute, /contract_status/);
+  assert.doesNotMatch(uploadRoute, /human_reviewed/);
+
+  // Auth gate is configurable via STUDIO_AUTH_MODE.
+  assert.match(studioAuth, /STUDIO_AUTH_MODE/);
+  assert.match(studioAuth, /Authentication required\./);
+  assert.match(studioAuth, /oai-authenticated-user-email/);
+
+  // Proxy forwards bearer/api-key credentials upstream.
+  assert.match(proxyRoute, /authorization/);
+  assert.match(proxyRoute, /x-api-key/);
+});


### PR DESCRIPTION
…mprove evaluation metrics

- Transport: optional QUERYFORGE_API_KEY auth + DATABASE_ALLOWLIST / REPORT_ROOT_ALLOWLIST path confinement for network entrypoints
- SSE: terminal final_result event carrying the answer/error, bounded queue, cooperative cancellation on client disconnect
- Reports: escape </script> breakout in chart spec JSON + CSP/nosniff
- Data assets: transactional publish (backup-based checkpoint, BEGIN IMMEDIATE, builder lock, bounded existing-key reads)
- Studio: configurable auth, honest server-side upload validation, run-history integrity (status/id/length validation, is_demo flag, ON CONFLICT DO NOTHING)
- Evaluation: real policy precision/recall over generated SQL, column-order-tolerant semantic equivalence, warmup-free latency, configurable exit-code gates
- Docs: sync README (EN/ZH), evaluation guide, .env.example

## Summary

<!-- What problem does this solve? -->

## Semantic and Security Impact

<!-- Metrics, grain, joins, visibility, SQL policy, or "none". -->

## Verification

- [ ] Focused tests added or updated
- [ ] `make check` passes
- [ ] Documentation updated
- [ ] No credentials, private data, or generated run state included
- [ ] Bundled sample data was preserved

## Compatibility

<!-- Migration notes, public import changes, or "none". -->
